### PR TITLE
[fix #4] Modify maybeGitHubShorthand regex

### DIFF
--- a/npa.js
+++ b/npa.js
@@ -133,7 +133,7 @@ function parseLocal (res, arg) {
 }
 
 function maybeGitHubShorthand (arg) {
-  return /^[^@ \/%]+\/[^@ \/%]+$/.test(arg)
+  return /^[^@ \/%]+\/[^@ \/%]+$/.test(arg) || /^[^@ \/%]+\/[^@ \/%]+[^@ #%]+[^@ \/%]+$/.test(arg)
 }
 
 function parseUrl (res, arg, urlparse) {

--- a/test/basic.js
+++ b/test/basic.js
@@ -98,6 +98,20 @@ require("tap").test("basic", function (t) {
       spec: "user/foo-js",
       raw: "user/foo-js"
     },
+    
+    "user/foo-js#bar/baz": {
+      name: null,
+      type: "github",
+      spec: "user/foo-js#bar/baz",
+      raw: "user/foo-js#bar/baz"
+    },
+    
+    "user/foo-js#bar/baz/bin": {
+      name: null,
+      type: "github",
+      spec: "user/foo-js#bar/baz/bin",
+      raw: "user/foo-js#bar/baz/bin"
+    },
 
     "foo@user/foo-js": {
       name: "foo",


### PR DESCRIPTION
the regex in maybeGitHubShorthand current fails when provided a branch with multiple slashes.  This is due to the current regex testing for a spec that only ever had a single slash.

I have added a second regular expression that checks for a pattern with multiple slashes following a hash.  I believe this could potentially be done more elegantly, as a single regular expression, but was unable to figure it out.

There are two tests included in test/basic.js to ensure that the provided regex works as expected.
