### PR TITLE
make `latest` the default for plain npm install

### DIFF
--- a/npa.js
+++ b/npa.js
@@ -102,7 +102,7 @@ function npa (arg) {
     if (p && validName(p[2]) &&
         (!p[1] || validName(p[1]))) {
       res.type = "range"
-      res.spec = "*"
+      res.spec = "latest"
       res.rawSpec = ""
       res.name = arg
       if (p[1])


### PR DESCRIPTION
When you do `npm install foo`, that usually translates to `npm install foo@*`, which excludes pre-release versions. Instead, simply make it so `npm install foo` is the same as `npm install foo@latest`.