### PR TITLE
New semantics for local specifiers and related changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules/
+.nyc_output
+coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 language: node_js
 node_js:
-  - "6"
-  - "5"
-  - "4"
-  - "0.12"
-  - "0.10"
+  - '6'
+  - '4'
+  - '7'
 sudo: false
 script: "npm test"
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,7 @@
 # npm-package-arg
 
-Parse package name and specifier passed to commands like `npm install` or
-`npm cache add`.  This just parses the text given-- it's worth noting that
-`npm` has further logic it applies by looking at your disk to figure out
-what ambiguous specifiers are.  If you want that logic, please see
-[realize-package-specifier].
-
-[realize-package-specifier]: https://www.npmjs.org/package/realize-package-specifier
-
-Arguments look like: `foo@1.2`, `@bar/foo@1.2`, `foo@user/foo`, `http://x.com/foo.tgz`,
-`git+https://github.com/user/foo`, `bitbucket:user/foo`, `foo.tar.gz` or `bar`
+Parses package name and specifier passed to commands like `npm install` or
+`npm cache add`, or as found in `package.json` dependency sections.
 
 ## EXAMPLES
 
@@ -18,93 +10,72 @@ var assert = require("assert")
 var npa = require("npm-package-arg")
 
 // Pass in the descriptor, and it'll return an object
-var parsed = npa("@bar/foo@1.2")
-
-// Returns an object like:
-{
-  raw: '@bar/foo@1.2',       // what was passed in
-  name: '@bar/foo',          // the name of the package
-  escapedName: '@bar%2ffoo', // the escaped name, for making requests against a registry
-  scope: '@bar',             // the scope of the package, or null
-  type: 'range',             // the type of specifier this is
-  spec: '>=1.2.0 <1.3.0',    // the expanded specifier
-  rawSpec: '1.2'             // the specifier as passed in
- }
-
-// Parsing urls pointing at hosted git services produces a variation:
-var parsed = npa("git+https://github.com/user/foo")
-
-// Returns an object like:
-{
-  raw: 'git+https://github.com/user/foo',
-  scope: null,
-  name: null,
-  escapedName: null,
-  rawSpec: 'git+https://github.com/user/foo',
-  spec: 'user/foo',
-  type: 'hosted',
-  hosted: {
-    type: 'github',
-    ssh: 'git@github.com:user/foo.git',
-    sshurl: 'git+ssh://git@github.com/user/foo.git',
-    https: 'https://github.com/user/foo.git',
-    directUrl: 'https://raw.githubusercontent.com/user/foo/master/package.json'
-  }
+try {
+  var parsed = npa("@bar/foo@1.2")
+} catch (ex) {
+  …
 }
-
-// Completely unreasonable invalid garbage throws an error
-// Make sure you wrap this in a try/catch if you have not
-// already sanitized the inputs!
-assert.throws(function() {
-  npa("this is not \0 a valid package name or url")
-})
 ```
 
 ## USING
 
 `var npa = require('npm-package-arg')`
 
-* var result = npa(*arg*)
+### var result = npa(*arg*[, *where*])
 
-Parses *arg* and returns a result object detailing what *arg* is.
+* *arg* - a string that you might pass to `npm install`, like:
+`foo@1.2`, `@bar/foo@1.2`, `foo@user/foo`, `http://x.com/foo.tgz`,
+`git+https://github.com/user/foo`, `bitbucket:user/foo`, `foo.tar.gz`,
+`../foo/bar/` or `bar`.  If the *arg* you provide doesn't have a specifier
+part, eg `foo` then the specifier will default to `latest`.
+* *where* - Optionally the path to resolve file paths relative to. Defaults to `process.cwd()`
 
-*arg* -- a package descriptor, like: `foo@1.2`, or `foo@user/foo`, or
-`http://x.com/foo.tgz`, or `git+https://github.com/user/foo`
+**Throws** if the package name is invalid, a dist-tag is invalid or a URL's protocol is not supported.
+
+### var result = npa.resolve(*name*, *spec*[, *where*])
+
+* *name* - The name of the module you want to install. For example: `foo` or `@bar/foo`.
+* *spec* - The specifier indicating where and how you can get this module. Something like:
+`1.2`, `^1.7.17`, `http://x.com/foo.tgz`, `git+https://github.com/user/foo`,
+`bitbucket:user/foo`, `file:foo.tar.gz` or `file:../foo/bar/`.  If not
+included then the default is `latest`.
+* *where* - Optionally the path to resolve file paths relative to. Defaults to `process.cwd()`
+
+**Throws** if the package name is invalid, a dist-tag is invalid or a URL's protocol is not supported.
 
 ## RESULT OBJECT
 
 The objects that are returned by npm-package-arg contain the following
 keys:
 
-* `name` - If known, the `name` field expected in the resulting pkg.
 * `type` - One of the following strings:
   * `git` - A git repo
-  * `hosted` - A hosted project, from github, bitbucket or gitlab. Originally
-    either a full url pointing at one of these services or a shorthand like
-    `user/project` or `github:user/project` for github or `bitbucket:user/project`
-    for bitbucket.
   * `tag` - A tagged version, like `"foo@latest"`
   * `version` - A specific version number, like `"foo@1.2.3"`
   * `range` - A version range, like `"foo@2.x"`
-  * `local` - A local file or folder path
+  * `file` - A local `.tar.gz`, `.tar` or `.tgz` file.
+  * `directory` - A local directory.
   * `remote` - An http url (presumably to a tgz)
-* `spec` - The "thing".  URL, the range, git repo, etc.
-* `hosted` - If type=hosted this will be an object with the following keys:
-  * `type` - github, bitbucket or gitlab
-  * `ssh` - The ssh path for this git repo
-  * `sshUrl` - The ssh URL for this git repo
-  * `httpsUrl` - The HTTPS URL for this git repo
-  * `directUrl` - The URL for the package.json in this git repo
-* `raw` - The original un-modified string that was provided.
-* `rawSpec` - The part after the `name@...`, as it was originally
-  provided.
+* `registry` - If true this specifier refers to a resource hosted on a
+  registry.  This is true for `tag`, `version` and `range` types.
+* `name` - If known, the `name` field expected in the resulting pkg.
 * `scope` - If a name is something like `@org/module` then the `scope`
   field will be set to `@org`.  If it doesn't have a scoped name, then
   scope is `null`.
 * `escapedName` - A version of `name` escaped to match the npm scoped packages
   specification. Mostly used when making requests against a registry. When
   `name` is `null`, `escapedName` will also be `null`.
-
-If you only include a name and no specifier part, eg, `foo` or `foo@` then
-a default of `latest` will be used (as of 4.1.0). This is contrast with
-previous behavior where `*` was used.
+* `rawSpec` - The specifier part that was parsed out in calls to `npa(arg)`,
+  or the value of `spec` in calls to `npa.resolve(name, spec).
+* `saveSpec` - The normalized specifier, for saving to package.json files.
+  `null` for registry dependencies.
+* `fetchSpec` - The version of the specifier to be used to fetch this
+  resource.  `null` for shortcuts to hosted git dependencies as there isn't
+  just one URL to try with them.
+* `gitRange` - If set, this is a semver specifier to match against git tags with
+* `gitCommittish` - If set, this is the specific committish to use with a git dependency.
+* `hosted` - If `from === 'hosted'` then this will be a `hosted-git-info`
+  object. This property is not included when serializing the object as
+  JSON.
+* `raw` - The original un-modified string that was provided.  If called as
+  `npa.resolve(name, spec)` then this will be `name + '@' + spec`.

--- a/npa.js
+++ b/npa.js
@@ -1,157 +1,193 @@
-var url = require('url')
-var assert = require('assert')
-var util = require('util')
-var semver = require('semver')
-var HostedGit = require('hosted-git-info')
-
+'use strict'
 module.exports = npa
+module.exports.resolve = resolve
+module.exports.Result = Result
 
-var isWindows = process.platform === 'win32' || global.FAKE_WINDOWS
-var slashRe = isWindows ? /\\|[/]/ : /[/]/
+let url
+let HostedGit
+let semver
+let path
+let validatePackageName
+let osenv
 
-var parseName = /^(?:@([^/]+?)[/])?([^/]+?)$/
-var nameAt = /^(@([^/]+?)[/])?([^/]+?)@/
-var debug = util.debuglog
-  ? util.debuglog('npa')
-  : /\bnpa\b/i.test(process.env.NODE_DEBUG || '')
-    ? function () {
-      console.error('NPA: ' + util.format.apply(util, arguments).split('\n').join('\nNPA: '))
+const isWindows = process.platform === 'win32' || global.FAKE_WINDOWS
+const hasSlashes = isWindows ? /\\|[/]/ : /[/]/
+const isURL = /^(?:git[+])?[a-z]+:/i
+const isFilename = /[.](?:tgz|tar.gz|tar)$/i
+
+function npa (arg, where) {
+  let name
+  let spec
+  const nameEndsAt = arg[0] === '@' ? arg.slice(1).indexOf('@') + 1 : arg.indexOf('@')
+  const namePart = nameEndsAt > 0 ? arg.slice(0, nameEndsAt) : arg
+  if (isURL.test(arg)) {
+    spec = arg
+  } else if (namePart[0] !== '@' && (hasSlashes.test(namePart) || isFilename.test(namePart))) {
+    spec = arg
+  } else if (nameEndsAt > 0) {
+    name = namePart
+    spec = arg.slice(nameEndsAt + 1)
+  } else {
+    if (!validatePackageName) validatePackageName = require('validate-npm-package-name')
+    const valid = validatePackageName(arg)
+    if (valid.validForOldPackages) {
+      name = arg
+    } else {
+      spec = arg
     }
-    : function () {}
-
-function validName (name) {
-  if (!name) {
-    debug('not a name %j', name)
-    return false
   }
-  var n = name.trim()
-  if (!n || n.charAt(0) === '.' ||
-    !n.match(/^[a-zA-Z0-9]/) ||
-    n.match(/[/()&?#|<>@:%\s\\*'"!~`]/) ||
-    n.toLowerCase() === 'node_modules' ||
-    n !== encodeURIComponent(n) ||
-    n.toLowerCase() === 'favicon.ico') {
-    debug('not a valid name %j', name)
-    return false
-  }
-  return n
+  return resolve(name, spec, where, arg)
 }
 
-function npa (arg) {
-  assert.equal(typeof arg, 'string')
-  arg = arg.trim()
+const isFilespec = isWindows ? /^(?:[.]|~[/]|[/\\]|[a-zA-Z]:)/ : /^(?:[.]|~[/]|[/]|[a-zA-Z]:)/
 
-  var res = new Result()
-  res.raw = arg
-  res.scope = null
-  res.escapedName = null
+function resolve (name, spec, where, arg) {
+  const res = new Result({
+    raw: arg,
+    name: name,
+    rawSpec: spec,
+    fromArgument: arg != null
+  })
 
-  // See if it's something like foo@...
-  var nameparse = arg.match(nameAt)
-  debug('nameparse', nameparse)
-  if (nameparse && validName(nameparse[3]) &&
-    (!nameparse[2] || validName(nameparse[2]))) {
-    res.name = (nameparse[1] || '') + nameparse[3]
-    res.escapedName = escapeName(res.name)
-    if (nameparse[2]) {
-      res.scope = '@' + nameparse[2]
-    }
-    arg = arg.substr(nameparse[0].length)
+  if (name) res.setName(name)
+
+  if (spec && (isFilespec.test(spec) || /^file:/i.test(spec))) {
+    return fromFile(res, where)
+  }
+  if (!HostedGit) HostedGit = require('hosted-git-info')
+  const hosted = HostedGit.fromUrl(spec, {noGitPlus: true, noCommittish: true})
+  if (hosted) {
+    return fromHostedGit(res, hosted)
+  } else if (spec && isURL.test(spec)) {
+    return fromURL(res)
+  } else if (spec && (hasSlashes.test(spec) || isFilename.test(spec))) {
+    return fromFile(res, where)
   } else {
-    res.name = null
+    return fromRegistry(res)
   }
+}
 
-  res.rawSpec = arg
-  res.spec = arg
+function invalidPackageName (name, valid) {
+  const err = new Error(`Invalid package name "${name}": ${valid.errors.join('; ')}`)
+  err.code = 'EINVALIDPACKAGENAME'
+  return err
+}
+function invalidTagName (name) {
+  const err = new Error(`Invalid tag name "${name}": Tags may not have any characters that encodeURIComponent encodes.`)
+  err.code = 'EINVALIDTAGNAME'
+  return err
+}
 
-  var urlparse = url.parse(arg)
-  debug('urlparse', urlparse)
-
-  // windows paths look like urls
-  // don't be fooled!
-  if (isWindows && urlparse && urlparse.protocol &&
-    urlparse.protocol.match(/^[a-zA-Z]:$/)) {
-    debug('windows url-ish local path', urlparse)
-    urlparse = {}
-  }
-
-  if (urlparse.protocol || HostedGit.fromUrl(arg)) {
-    return parseUrl(res, arg, urlparse)
-  }
-
-  // at this point, it's not a url, and not hosted
-  // If it's a valid name, and doesn't already have a name, then assume
-  // $name@"" range
-  //
-  // if it's got / chars in it, then assume that it's local.
-
-  if (res.name) {
-    if (arg === '') arg = 'latest'
-    var version = semver.valid(arg, true)
-    var range = semver.validRange(arg, true)
-    // foo@...
-    if (version) {
-      res.spec = version
-      res.type = 'version'
-    } else if (range) {
-      res.spec = range
-      res.type = 'range'
-    } else if (slashRe.test(arg)) {
-      parseLocal(res, arg)
-    } else {
-      res.type = 'tag'
-      res.spec = arg
-    }
+function Result (opts) {
+  this.type = opts.type
+  this.registry = opts.registry
+  this.where = opts.where
+  if (opts.raw == null) {
+    this.raw = opts.name ? opts.name + '@' + opts.rawSpec : opts.rawSpec
   } else {
-    var p = arg.match(parseName)
-    if (p && validName(p[2]) &&
-      (!p[1] || validName(p[1]))) {
-      res.type = 'tag'
-      res.spec = 'latest'
-      res.rawSpec = ''
-      res.name = arg
-      res.escapedName = escapeName(res.name)
-      if (p[1]) {
-        res.scope = '@' + p[1]
-      }
-    } else {
-      parseLocal(res, arg)
-    }
+    this.raw = opts.raw
   }
+  this.name = undefined
+  this.escapedName = undefined
+  this.scope = undefined
+  this.rawSpec = opts.rawSpec == null ? '' : opts.rawSpec
+  this.saveSpec = opts.saveSpec
+  this.fetchSpec = opts.fetchSpec
+  if (opts.name) this.setName(opts.name)
+  this.gitRange = opts.gitRange
+  this.gitCommittish = opts.gitCommittish
+  this.hosted = opts.hosted
+}
+Result.prototype = {}
 
+Result.prototype.setName = function (name) {
+  if (!validatePackageName) validatePackageName = require('validate-npm-package-name')
+  const valid = validatePackageName(name)
+  if (!valid.validForOldPackages) {
+    throw invalidPackageName(name, valid)
+  }
+  this.name = name
+  this.scope = name[0] === '@' ? name.slice(0, name.indexOf('/')) : undefined
+  // scoped packages in couch must have slash url-encoded, e.g. @foo%2Fbar
+  this.escapedName = name.replace('/', '%2f')
+  return this
+}
+
+Result.prototype.toJSON = function () {
+  const result = Object.assign({}, this)
+  delete result.hosted
+  return result
+}
+
+function setGitCommittish (res, committish) {
+  if (committish != null && committish.length >= 7 && committish.slice(0, 7) === 'semver:') {
+    res.gitRange = decodeURIComponent(committish.slice(7))
+    res.gitCommittish = null
+  } else if (committish == null || committish === '') {
+    res.gitCommittish = 'master'
+  } else {
+    res.gitCommittish = committish
+  }
   return res
 }
 
-function escapeName (name) {
-  // scoped packages in couch must have slash url-encoded, e.g. @foo%2Fbar
-  return name && name.replace('/', '%2f')
+const isAbsolutePath = /^[/]|^[A-Za-z]:/
+
+function resolvePath (where, spec) {
+  if (isAbsolutePath.test(spec)) return spec
+  if (!path) path = require('path')
+  return path.resolve(where, spec)
 }
 
-function parseLocal (res, arg) {
-  // turns out nearly every character is allowed in fs paths
-  if (/\0/.test(arg)) {
-    throw new Error('Invalid Path: ' + JSON.stringify(arg))
-  }
-  res.type = 'local'
-  res.spec = arg
+function isAbsolute (dir) {
+  if (dir[0] === '/') return true
+  if (/^[A-Za-z]:/.test(dir)) return true
+  return false
 }
 
-function parseUrl (res, arg, urlparse) {
-  var gitHost = HostedGit.fromUrl(arg)
-  if (gitHost) {
-    res.type = 'hosted'
-    res.spec = gitHost.toString()
-    res.hosted = {
-      type: gitHost.type,
-      ssh: gitHost.ssh(),
-      sshUrl: gitHost.sshurl(),
-      httpsUrl: gitHost.https(),
-      gitUrl: gitHost.git(),
-      shortcut: gitHost.shortcut(),
-      directUrl: gitHost.file('package.json')
+function fromFile (res, where) {
+  if (!where) where = process.cwd()
+  res.type = isFilename.test(res.rawSpec) ? 'file' : 'directory'
+  res.where = where
+
+  const spec = res.rawSpec.replace(/\\/g, '/')
+    .replace(/^file:[/]*([A-Za-z]:)/, '$1') // drive name paths on windows
+    .replace(/^file:(?:[/]*([~./]))?/, '$1')
+  if (/^~[/]/.test(spec)) {
+    // this is needed for windows and for file:~/foo/bar
+    if (!osenv) osenv = require('osenv')
+    res.fetchSpec = resolvePath(osenv.home(), spec.slice(2))
+    res.saveSpec = 'file:' + spec
+  } else {
+    res.fetchSpec = resolvePath(where, spec)
+    if (isAbsolute(spec)) {
+      res.saveSpec = 'file:' + spec
+    } else {
+      if (!path) path = require('path')
+      res.saveSpec = 'file:' + path.relative(where, res.fetchSpec)
     }
-    return res
   }
+  return res
+}
+
+function fromHostedGit (res, hosted) {
+  res.type = 'git'
+  res.hosted = hosted
+  res.saveSpec = hosted.toString({noGitPlus: false, noCommittish: false})
+  res.fetchSpec = hosted.getDefaultRepresentation() === 'shortcut' ? null : hosted.toString()
+  return setGitCommittish(res, hosted.committish)
+}
+
+function unsupportedURLType (protocol, spec) {
+  const err = new Error(`Unsupported URL Type "${protocol}": ${spec}`)
+  err.code = 'EUNSUPPORTEDPROTOCOL'
+  return err
+}
+
+function fromURL (res) {
+  if (!url) url = require('url')
+  const urlparse = url.parse(res.rawSpec)
+  res.saveSpec = res.rawSpec
   // check the protocol, and then see if it's git or not
   switch (urlparse.protocol) {
     case 'git:':
@@ -162,38 +198,44 @@ function parseUrl (res, arg, urlparse) {
     case 'git+ssh:':
     case 'git+file:':
       res.type = 'git'
-      res.spec = arg.replace(/^git[+]/, '')
+      setGitCommittish(res, urlparse.hash != null ? urlparse.hash.slice(1) : '')
+      urlparse.protocol = urlparse.protocol.replace(/^git[+]/, '')
+      delete urlparse.hash
+      res.fetchSpec = url.format(urlparse)
       break
 
     case 'http:':
     case 'https:':
       res.type = 'remote'
-      res.spec = arg
-      break
-
-    case 'file:':
-      res.type = 'local'
-      if (isWindows && arg.match(/^file:\/\/\/?[a-z]:/i)) {
-        // Windows URIs usually parse all wrong, so we just take matters
-        // into our own hands, in this case.
-        res.spec = arg.replace(/^file:\/\/\/?/i, '')
-      } else {
-        res.spec = urlparse.pathname
-      }
+      res.fetchSpec = res.saveSpec
       break
 
     default:
-      throw new Error('Unsupported URL Type: ' + arg)
+      throw unsupportedURLType(urlparse.protocol, res.rawSpec)
   }
 
   return res
 }
 
-function Result () {
-  if (!(this instanceof Result)) return new Result()
+function fromRegistry (res) {
+  res.registry = true
+  const spec = res.rawSpec === '' ? 'latest' : res.rawSpec
+  // no save spec for registry components as we save based on the fetched
+  // version, not on the argument so this can't compute that.
+  res.saveSpec = null
+  res.fetchSpec = spec
+  if (!semver) semver = require('semver')
+  const version = semver.valid(spec, true)
+  const range = semver.validRange(spec, true)
+  if (version) {
+    res.type = 'version'
+  } else if (range) {
+    res.type = 'range'
+  } else {
+    if (encodeURIComponent(spec) !== spec) {
+      throw invalidTagName(spec)
+    }
+    res.type = 'tag'
+  }
+  return res
 }
-Result.prototype.name = null
-Result.prototype.type = null
-Result.prototype.spec = null
-Result.prototype.raw = null
-Result.prototype.hosted = null

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
   ],
   "dependencies": {
     "hosted-git-info": "^2.4.2",
-    "semver": "^5.1.0"
+    "osenv": "^0.1.4",
+    "semver": "^5.1.0",
+    "validate-npm-package-name": "^3.0.0"
   },
   "devDependencies": {
     "standard": "9.0.2",

--- a/package.json
+++ b/package.json
@@ -15,10 +15,10 @@
   },
   "devDependencies": {
     "standard": "9.0.2",
-    "tap": "^5.7.2"
+    "tap": "^10.3.0"
   },
   "scripts": {
-    "test": "standard && tap --coverage test/*.js"
+    "test": "standard && tap -J --coverage test/*.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "semver": "^5.1.0"
   },
   "devDependencies": {
-    "standard": "^7.1.2",
+    "standard": "9.0.2",
     "tap": "^5.7.2"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "npa.js"
   ],
   "dependencies": {
-    "hosted-git-info": "^2.1.5",
+    "hosted-git-info": "^2.4.2",
     "semver": "^5.1.0"
   },
   "devDependencies": {

--- a/test/bitbucket.js
+++ b/test/bitbucket.js
@@ -6,66 +6,58 @@ require('tap').test('basic', function (t) {
   var tests = {
     'bitbucket:user/foo-js': {
       name: null,
-      type: 'hosted',
-      hosted: { type: 'bitbucket' },
-      spec: 'bitbucket:user/foo-js',
+      type: 'git',
+      saveSpec: 'bitbucket:user/foo-js',
       raw: 'bitbucket:user/foo-js'
     },
 
     'bitbucket:user/foo-js#bar/baz': {
       name: null,
-      type: 'hosted',
-      hosted: { type: 'bitbucket' },
-      spec: 'bitbucket:user/foo-js#bar/baz',
+      type: 'git',
+      saveSpec: 'bitbucket:user/foo-js#bar/baz',
       raw: 'bitbucket:user/foo-js#bar/baz'
     },
 
     'bitbucket:user..blerg--/..foo-js# . . . . . some . tags / / /': {
       name: null,
-      type: 'hosted',
-      hosted: { type: 'bitbucket' },
-      spec: 'bitbucket:user..blerg--/..foo-js# . . . . . some . tags / / /',
+      type: 'git',
+      saveSpec: 'bitbucket:user..blerg--/..foo-js# . . . . . some . tags / / /',
       raw: 'bitbucket:user..blerg--/..foo-js# . . . . . some . tags / / /'
     },
 
     'bitbucket:user/foo-js#bar/baz/bin': {
       name: null,
-      type: 'hosted',
-      hosted: { type: 'bitbucket' },
-      spec: 'bitbucket:user/foo-js#bar/baz/bin',
+      type: 'git',
+      saveSpec: 'bitbucket:user/foo-js#bar/baz/bin',
       raw: 'bitbucket:user/foo-js#bar/baz/bin'
     },
 
     'foo@bitbucket:user/foo-js': {
       name: 'foo',
-      type: 'hosted',
-      hosted: { type: 'bitbucket' },
-      spec: 'bitbucket:user/foo-js',
+      type: 'git',
+      saveSpec: 'bitbucket:user/foo-js',
       raw: 'foo@bitbucket:user/foo-js'
     },
 
     'git+ssh://git@bitbucket.org/user/foo#1.2.3': {
       name: null,
-      type: 'hosted',
-      hosted: { type: 'bitbucket' },
-      spec: 'git+ssh://git@bitbucket.org/user/foo.git#1.2.3',
+      type: 'git',
+      saveSpec: 'git+ssh://git@bitbucket.org/user/foo.git#1.2.3',
       raw: 'git+ssh://git@bitbucket.org/user/foo#1.2.3'
     },
 
     'https://bitbucket.org/user/foo.git': {
       name: null,
-      type: 'hosted',
-      hosted: { type: 'bitbucket' },
-      spec: 'git+https://bitbucket.org/user/foo.git',
+      type: 'git',
+      saveSpec: 'git+https://bitbucket.org/user/foo.git',
       raw: 'https://bitbucket.org/user/foo.git'
     },
 
     '@foo/bar@git+ssh://bitbucket.org/user/foo': {
       name: '@foo/bar',
       scope: '@foo',
-      type: 'hosted',
-      hosted: { type: 'bitbucket' },
-      spec: 'git+ssh://git@bitbucket.org/user/foo.git',
+      type: 'git',
+      saveSpec: 'git+ssh://git@bitbucket.org/user/foo.git',
       rawSpec: 'git+ssh://bitbucket.org/user/foo',
       raw: '@foo/bar@git+ssh://bitbucket.org/user/foo'
     }
@@ -73,7 +65,7 @@ require('tap').test('basic', function (t) {
 
   Object.keys(tests).forEach(function (arg) {
     var res = npa(arg)
-    t.type(res, 'Result', arg + ' is a result')
+    t.ok(res instanceof npa.Result, arg + ' is a result')
     t.has(res, tests[arg], arg + ' matches expectations')
   })
 

--- a/test/github.js
+++ b/test/github.js
@@ -6,97 +6,86 @@ require('tap').test('basic', function (t) {
   var tests = {
     'user/foo-js': {
       name: null,
-      type: 'hosted',
-      hosted: { type: 'github' },
-      spec: 'github:user/foo-js',
+      type: 'git',
+      saveSpec: 'github:user/foo-js',
       raw: 'user/foo-js'
     },
 
     'user/foo-js#bar/baz': {
       name: null,
-      type: 'hosted',
-      hosted: { type: 'github' },
-      spec: 'github:user/foo-js#bar/baz',
+      type: 'git',
+      saveSpec: 'github:user/foo-js#bar/baz',
       raw: 'user/foo-js#bar/baz'
     },
 
     'user..blerg--/..foo-js# . . . . . some . tags / / /': {
       name: null,
-      type: 'hosted',
-      hosted: { type: 'github' },
-      spec: 'github:user..blerg--/..foo-js# . . . . . some . tags / / /',
+      type: 'git',
+      saveSpec: 'github:user..blerg--/..foo-js# . . . . . some . tags / / /',
       raw: 'user..blerg--/..foo-js# . . . . . some . tags / / /'
     },
 
     'user/foo-js#bar/baz/bin': {
       name: null,
-      type: 'hosted',
-      hosted: { type: 'github' },
+      type: 'git',
       raw: 'user/foo-js#bar/baz/bin'
     },
 
     'foo@user/foo-js': {
       name: 'foo',
-      type: 'hosted',
-      hosted: { type: 'github' },
-      spec: 'github:user/foo-js',
+      type: 'git',
+      saveSpec: 'github:user/foo-js',
       raw: 'foo@user/foo-js'
     },
 
     'github:user/foo-js': {
       name: null,
-      type: 'hosted',
-      hosted: { type: 'github' },
-      spec: 'github:user/foo-js',
+      type: 'git',
+      saveSpec: 'github:user/foo-js',
       raw: 'github:user/foo-js'
     },
 
     'git+ssh://git@github.com/user/foo#1.2.3': {
       name: null,
-      type: 'hosted',
-      hosted: { type: 'github' },
-      spec: 'git+ssh://git@github.com/user/foo.git#1.2.3',
+      type: 'git',
+      saveSpec: 'git+ssh://git@github.com/user/foo.git#1.2.3',
       raw: 'git+ssh://git@github.com/user/foo#1.2.3'
     },
 
     'git://github.com/user/foo': {
       name: null,
-      type: 'hosted',
-      hosted: { type: 'github' },
-      spec: 'git://github.com/user/foo.git',
+      type: 'git',
+      saveSpec: 'git://github.com/user/foo.git',
       raw: 'git://github.com/user/foo'
     },
 
     'https://github.com/user/foo.git': {
       name: null,
-      type: 'hosted',
-      hosted: { type: 'github' },
-      spec: 'git+https://github.com/user/foo.git',
+      type: 'git',
+      saveSpec: 'git+https://github.com/user/foo.git',
       raw: 'https://github.com/user/foo.git'
     },
 
     '@foo/bar@git+ssh://github.com/user/foo': {
       name: '@foo/bar',
       scope: '@foo',
-      type: 'hosted',
-      hosted: { type: 'github' },
-      spec: 'git+ssh://git@github.com/user/foo.git',
+      type: 'git',
+      saveSpec: 'git+ssh://git@github.com/user/foo.git',
       rawSpec: 'git+ssh://github.com/user/foo',
       raw: '@foo/bar@git+ssh://github.com/user/foo'
     },
 
     'foo@bar/foo': {
       name: 'foo',
-      type: 'hosted',
-      hosted: { type: 'github' },
-      spec: 'github:bar/foo',
+      type: 'git',
+      saveSpec: 'github:bar/foo',
       raw: 'foo@bar/foo'
     }
   }
 
   Object.keys(tests).forEach(function (arg) {
     var res = npa(arg)
-    t.type(res, 'Result', arg + ' is a result')
+    t.ok(res instanceof npa.Result, arg + ' is a result')
     t.has(res, tests[arg], arg + ' matches expectations')
   })
 

--- a/test/gitlab.js
+++ b/test/gitlab.js
@@ -6,64 +6,56 @@ require('tap').test('basic', function (t) {
   var tests = {
     'gitlab:user/foo-js': {
       name: null,
-      type: 'hosted',
-      hosted: { type: 'gitlab' },
+      type: 'git',
       raw: 'gitlab:user/foo-js'
     },
 
     'gitlab:user/foo-js#bar/baz': {
       name: null,
-      type: 'hosted',
-      hosted: { type: 'gitlab' },
+      type: 'git',
       raw: 'gitlab:user/foo-js#bar/baz'
     },
 
     'gitlab:user..blerg--/..foo-js# . . . . . some . tags / / /': {
       name: null,
-      type: 'hosted',
-      hosted: { type: 'gitlab' },
-      spec: 'gitlab:user..blerg--/..foo-js# . . . . . some . tags / / /',
+      type: 'git',
+      saveSpec: 'gitlab:user..blerg--/..foo-js# . . . . . some . tags / / /',
       raw: 'gitlab:user..blerg--/..foo-js# . . . . . some . tags / / /'
     },
 
     'gitlab:user/foo-js#bar/baz/bin': {
       name: null,
-      type: 'hosted',
-      hosted: { type: 'gitlab' },
-      spec: 'gitlab:user/foo-js#bar/baz/bin',
+      type: 'git',
+      saveSpec: 'gitlab:user/foo-js#bar/baz/bin',
       raw: 'gitlab:user/foo-js#bar/baz/bin'
     },
 
     'foo@gitlab:user/foo-js': {
       name: 'foo',
-      type: 'hosted',
-      hosted: { type: 'gitlab' },
-      spec: 'gitlab:user/foo-js',
+      type: 'git',
+      saveSpec: 'gitlab:user/foo-js',
       raw: 'foo@gitlab:user/foo-js'
     },
 
     'git+ssh://git@gitlab.com/user/foo#1.2.3': {
       name: null,
-      type: 'hosted',
-      hosted: { type: 'gitlab' },
-      spec: 'git+ssh://git@gitlab.com/user/foo.git#1.2.3',
+      type: 'git',
+      saveSpec: 'git+ssh://git@gitlab.com/user/foo.git#1.2.3',
       raw: 'git+ssh://git@gitlab.com/user/foo#1.2.3'
     },
 
     'https://gitlab.com/user/foo.git': {
       name: null,
-      type: 'hosted',
-      hosted: { type: 'gitlab' },
-      spec: 'git+https://gitlab.com/user/foo.git',
+      type: 'git',
+      saveSpec: 'git+https://gitlab.com/user/foo.git',
       raw: 'https://gitlab.com/user/foo.git'
     },
 
     '@foo/bar@git+ssh://gitlab.com/user/foo': {
       name: '@foo/bar',
       scope: '@foo',
-      type: 'hosted',
-      hosted: { type: 'gitlab' },
-      spec: 'git+ssh://git@gitlab.com/user/foo.git',
+      type: 'git',
+      saveSpec: 'git+ssh://git@gitlab.com/user/foo.git',
       rawSpec: 'git+ssh://gitlab.com/user/foo',
       raw: '@foo/bar@git+ssh://gitlab.com/user/foo'
     }
@@ -71,8 +63,8 @@ require('tap').test('basic', function (t) {
 
   Object.keys(tests).forEach(function (arg) {
     var res = npa(arg)
-    t.type(res, 'Result', arg + ' is a result')
-    t.has(res, tests[arg], arg + ' matches expectations')
+    t.ok(res instanceof npa.Result, arg + ' is a result')
+    t.has(JSON.parse(JSON.stringify(res)), tests[arg], arg + ' matches expectations')
   })
 
   t.end()

--- a/test/realize-package-specifier.js
+++ b/test/realize-package-specifier.js
@@ -1,0 +1,43 @@
+'use strict'
+var test = require('tap').test
+var npa = require('../npa.js')
+
+test('realize-package-specifier', function (t) {
+  t.plan(6)
+  var result
+  result = npa('a.tar.gz', '/test/a/b')
+  t.is(result.type, 'file', 'local tarball')
+  result = npa('d', '/test/a/b')
+  t.is(result.type, 'tag', 'remote package')
+  result = npa('file:./a.tar.gz', '/test/a/b')
+  t.is(result.type, 'file', 'local tarball')
+  result = npa('file:./b', '/test/a/b')
+  t.is(result.type, 'directory', 'local package directory')
+  result = npa('file:./c', '/test/a/b')
+  t.is(result.type, 'directory', 'non-package local directory, specified with a file URL')
+  result = npa('file:./d', '/test/a/b')
+  t.is(result.type, 'directory', 'no local directory, specified with a file URL')
+})
+test('named realize-package-specifier', function (t) {
+  t.plan(10)
+  var result
+  result = npa('a@a.tar.gz', '/test/a/b')
+  t.is(result.type, 'file', 'named local tarball')
+  result = npa('d@d', '/test/a/b')
+  t.is(result.type, 'tag', 'remote package')
+  result = npa('a@file:./a.tar.gz', '/test/a/b')
+  t.is(result.type, 'file', 'local tarball')
+  result = npa('b@file:./b', '/test/a/b')
+  t.is(result.type, 'directory', 'local package directory')
+  result = npa('c@file:./c', '/test/a/b')
+  t.is(result.type, 'directory', 'non-package local directory, specified with a file URL')
+  result = npa('d@file:./d', '/test/a/b')
+  t.is(result.type, 'directory', 'no local directory, specified with a file URL')
+  result = npa('e@e/2', 'test/a/b')
+  t.is(result.type, 'git', 'hosted package dependency is git')
+  t.is(result.hosted.type, 'github', 'github package dependency')
+  result = npa('e@1', '/test/a/b')
+  t.is(result.type, 'range', 'range like specifier is never a local file')
+  result = npa('e@1.0.0', '/test/a/b')
+  t.is(result.type, 'version', 'version like specifier is never a local file')
+})

--- a/test/windows.js
+++ b/test/windows.js
@@ -10,8 +10,8 @@ var cases = {
     name: null,
     escapedName: null,
     rawSpec: 'C:\\x\\y\\z',
-    spec: 'C:\\x\\y\\z',
-    type: 'local'
+    fetchSpec: 'C:/x/y/z',
+    type: 'directory'
   },
   'foo@C:\\x\\y\\z': {
     raw: 'foo@C:\\x\\y\\z',
@@ -19,8 +19,8 @@ var cases = {
     name: 'foo',
     escapedName: 'foo',
     rawSpec: 'C:\\x\\y\\z',
-    spec: 'C:\\x\\y\\z',
-    type: 'local'
+    fetchSpec: 'C:/x/y/z',
+    type: 'directory'
   },
   'foo@file:///C:\\x\\y\\z': {
     raw: 'foo@file:///C:\\x\\y\\z',
@@ -28,8 +28,8 @@ var cases = {
     name: 'foo',
     escapedName: 'foo',
     rawSpec: 'file:///C:\\x\\y\\z',
-    spec: 'C:\\x\\y\\z',
-    type: 'local'
+    fetchSpec: 'C:/x/y/z',
+    type: 'directory'
   },
   'foo@file://C:\\x\\y\\z': {
     raw: 'foo@file://C:\\x\\y\\z',
@@ -37,8 +37,8 @@ var cases = {
     name: 'foo',
     escapedName: 'foo',
     rawSpec: 'file://C:\\x\\y\\z',
-    spec: 'C:\\x\\y\\z',
-    type: 'local'
+    fetchSpec: 'C:/x/y/z',
+    type: 'directory'
   },
   'file:///C:\\x\\y\\z': {
     raw: 'file:///C:\\x\\y\\z',
@@ -46,8 +46,8 @@ var cases = {
     name: null,
     escapedName: null,
     rawSpec: 'file:///C:\\x\\y\\z',
-    spec: 'C:\\x\\y\\z',
-    type: 'local'
+    fetchSpec: 'C:/x/y/z',
+    type: 'directory'
   },
   'file://C:\\x\\y\\z': {
     raw: 'file://C:\\x\\y\\z',
@@ -55,8 +55,8 @@ var cases = {
     name: null,
     escapedName: null,
     rawSpec: 'file://C:\\x\\y\\z',
-    spec: 'C:\\x\\y\\z',
-    type: 'local'
+    fetchSpec: 'C:/x/y/z',
+    type: 'directory'
   },
   'foo@/foo/bar/baz': {
     raw: 'foo@/foo/bar/baz',
@@ -64,8 +64,8 @@ var cases = {
     name: 'foo',
     escapedName: 'foo',
     rawSpec: '/foo/bar/baz',
-    spec: '/foo/bar/baz',
-    type: 'local'
+    fetchSpec: '/foo/bar/baz',
+    type: 'directory'
   }
 }
 
@@ -73,7 +73,7 @@ test('parse a windows path', function (t) {
   Object.keys(cases).forEach(function (c) {
     var expect = cases[c]
     var actual = npa(c)
-    t.same(actual, expect, c)
+    t.has(actual, expect, c)
   })
   t.end()
 })


### PR DESCRIPTION
There are also a number of other changes to improve the experience of using
this library. `realize-package-specifier` should no longer be needed.

* New properties:
  * `registry` - If true this specifier refers to a resource hosted on a
    registry.  This is true for `tag`, `version` and `range` types.
  * `saveSpec` - A normalized form of the specifier that can be fed back
    into `npm-package-arg` to get identical results.
  * `fetchSpec` - The information necessary to fetch this resource without
    further processing.  For git sources, this can be passed directly to git
    clone, for files, `fs.readFile`, and so on.
  * `gitRange` - If the user requested a git URL with a semver range, eg
    `git+ssh://site.com/foo.git#semver:^1.0.0` then this holds the range part.
  * `gitCommittish' - If the user requested a git URL with a specific
    branch, tag or commit then this holds that value.

* Removed properties:
  * `spec` - Has been replaced by `saveSpec` and `fetchSpec` respectively.

* Changed properties:
  * `type` indicates what sort of specifier this is, values are: `file`,
    `directory`, `git`, `remote`, `version`, `range`, `tag`.
  * `hosted` is now a `hosted-git-info` object, not a map containing strings.

* Changes to local specifiers:
  * Trailing spaces on local specifiers are no longer trimmed.
  * The `spec` field for local specifiers is now a fully resolved path.
  * The type is now `file` or `directory, never `local`.
* Changes to git specifiers:
  * `saveSpec` does not remove the `git+` prefix. `fetchSpec` does.
* Changes to hosted git specifiers:
  * The `type` is now _git_.  You can check if something is hosted by
    looking at the `hosted` property.
