### PR TITLE
Fix path handling for git dependencies with paths that start with :

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 .nyc_output
 coverage
+.vscode

--- a/npa.js
+++ b/npa.js
@@ -209,6 +209,7 @@ function fromURL (res) {
       setGitCommittish(res, urlparse.hash != null ? urlparse.hash.slice(1) : '')
       urlparse.protocol = urlparse.protocol.replace(/^git[+]/, '')
       delete urlparse.hash
+      urlparse.pathname = urlparse.pathname.replace(/^\/:/, '/')
       res.fetchSpec = url.format(urlparse)
       break
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -98,6 +98,16 @@ require('tap').test('basic', function (t) {
       raw: 'git+ssh://git@notgithub.com/user/foo#1.2.3'
     },
 
+    'git+ssh://git@notgithub.com:user/foo#1.2.3': {
+      name: null,
+      escapedName: null,
+      type: 'git',
+      saveSpec: 'git+ssh://git@notgithub.com:user/foo#1.2.3',
+      fetchSpec: 'ssh://git@notgithub.com/user/foo',
+      gitCommittish: '1.2.3',
+      raw: 'git+ssh://git@notgithub.com:user/foo#1.2.3'
+    },
+
     'git+ssh://git@github.com/user/foo#1.2.3': {
       name: null,
       escapedName: null,


### PR DESCRIPTION
Part of a fix for https://github.com/npm/npm/issues/16726

It turns out that if you specify a dependency like `git+ssh://git@notgithub.com:user/foo#1.2.3` with a colon separating the path from the host, `npm-package-arg` returns an invalid path as a `fetchSpec` (`ssh://git@notgithub.com/:user/foo`, which in turn was throwing off all git operations in the fetcher in pacote. `git+ssh://git@notgithub.com:user/foo#1.2.3` dependencies do work in npm 4, though.

This doesn't completely fix https://github.com/npm/npm/issues/16726 though - there's one more tiny fix left for pacote (PR for that coming soon!)