### PR TITLE
git: add support for scp-style git specs

### DIFF
--- a/npa.js
+++ b/npa.js
@@ -192,6 +192,22 @@ function unsupportedURLType (protocol, spec) {
   return err
 }
 
+function matchGitScp (spec) {
+  // git ssh specifiers are overloaded to also use scp-style git
+  // specifiers, so we have to parse those out and treat them special.
+  // They are NOT true URIs, so we can't hand them to `url.parse`.
+  //
+  // This regex looks for things that look like:
+  // git+ssh://git@my.custom.git.com:username/project.git#deadbeef
+  //
+  // ...and various combinations. The username in the beginning is *required*.
+  const matched = spec.match(/^git\+ssh:\/\/([^:]+:[^#]+(?:\.git)?)(?:#(.*))$/i)
+  return matched && !matched[1].match(/:[0-9]+\/?.*$/i) && {
+    fetchSpec: matched[1],
+    gitCommittish: matched[2]
+  }
+}
+
 function fromURL (res) {
   if (!url) url = require('url')
   const urlparse = url.parse(res.rawSpec)
@@ -203,15 +219,20 @@ function fromURL (res) {
     case 'git+https:':
     case 'git+rsync:':
     case 'git+ftp:':
-    case 'git+ssh:':
     case 'git+file:':
+    case 'git+ssh:':
       res.type = 'git'
-      setGitCommittish(res, urlparse.hash != null ? urlparse.hash.slice(1) : '')
-      urlparse.protocol = urlparse.protocol.replace(/^git[+]/, '')
-      delete urlparse.hash
-      res.fetchSpec = url.format(urlparse)
+      const match = urlparse.protocol === 'git+ssh:' && matchGitScp(res.rawSpec)
+      if (match) {
+        res.fetchSpec = match.fetchSpec
+        res.gitCommittish = match.gitCommittish
+      } else {
+        setGitCommittish(res, urlparse.hash != null ? urlparse.hash.slice(1) : '')
+        urlparse.protocol = urlparse.protocol.replace(/^git[+]/, '')
+        delete urlparse.hash
+        res.fetchSpec = url.format(urlparse)
+      }
       break
-
     case 'http:':
     case 'https:':
       res.type = 'remote'

--- a/test/basic.js
+++ b/test/basic.js
@@ -98,6 +98,66 @@ require('tap').test('basic', function (t) {
       raw: 'git+ssh://git@notgithub.com/user/foo#1.2.3'
     },
 
+    'git+ssh://git@notgithub.com:user/foo#1.2.3': {
+      name: null,
+      escapedName: null,
+      type: 'git',
+      saveSpec: 'git+ssh://git@notgithub.com:user/foo#1.2.3',
+      fetchSpec: 'git@notgithub.com:user/foo',
+      gitCommittish: '1.2.3',
+      raw: 'git+ssh://git@notgithub.com:user/foo#1.2.3'
+    },
+
+    'git+ssh://mydomain.com:foo#1.2.3': {
+      name: null,
+      escapedName: null,
+      type: 'git',
+      saveSpec: 'git+ssh://mydomain.com:foo#1.2.3',
+      fetchSpec: 'mydomain.com:foo',
+      gitCommittish: '1.2.3',
+      raw: 'git+ssh://mydomain.com:foo#1.2.3'
+    },
+
+    'git+ssh://mydomain.com:foo/bar#1.2.3': {
+      name: null,
+      escapedName: null,
+      type: 'git',
+      saveSpec: 'git+ssh://mydomain.com:foo/bar#1.2.3',
+      fetchSpec: 'mydomain.com:foo/bar',
+      gitCommittish: '1.2.3',
+      raw: 'git+ssh://mydomain.com:foo/bar#1.2.3'
+    },
+
+    'git+ssh://mydomain.com:1234#1.2.3': {
+      name: null,
+      escapedName: null,
+      type: 'git',
+      saveSpec: 'git+ssh://mydomain.com:1234#1.2.3',
+      fetchSpec: 'ssh://mydomain.com:1234',
+      gitCommittish: '1.2.3',
+      raw: 'git+ssh://mydomain.com:1234#1.2.3'
+    },
+
+    'git+ssh://mydomain.com:1234/hey#1.2.3': {
+      name: null,
+      escapedName: null,
+      type: 'git',
+      saveSpec: 'git+ssh://mydomain.com:1234/hey#1.2.3',
+      fetchSpec: 'ssh://mydomain.com:1234/hey',
+      gitCommittish: '1.2.3',
+      raw: 'git+ssh://mydomain.com:1234/hey#1.2.3'
+    },
+
+    'git+ssh://username:password@mydomain.com:1234/hey#1.2.3': {
+      name: null,
+      escapedName: null,
+      type: 'git',
+      saveSpec: 'git+ssh://username:password@mydomain.com:1234/hey#1.2.3',
+      fetchSpec: 'ssh://username:password@mydomain.com:1234/hey',
+      gitCommittish: '1.2.3',
+      raw: 'git+ssh://username:password@mydomain.com:1234/hey#1.2.3'
+    },
+
     'git+ssh://git@github.com/user/foo#1.2.3': {
       name: null,
       escapedName: null,

--- a/test/basic.js
+++ b/test/basic.js
@@ -98,16 +98,6 @@ require('tap').test('basic', function (t) {
       raw: 'git+ssh://git@notgithub.com/user/foo#1.2.3'
     },
 
-    'git+ssh://git@notgithub.com:user/foo#1.2.3': {
-      name: null,
-      escapedName: null,
-      type: 'git',
-      saveSpec: 'git+ssh://git@notgithub.com:user/foo#1.2.3',
-      fetchSpec: 'git@notgithub.com:user/foo',
-      gitCommittish: '1.2.3',
-      raw: 'git+ssh://git@notgithub.com:user/foo#1.2.3'
-    },
-
     'git+ssh://git@github.com/user/foo#1.2.3': {
       name: null,
       escapedName: null,

--- a/test/github.js
+++ b/test/github.js
@@ -52,13 +52,6 @@ require('tap').test('basic', function (t) {
       raw: 'git+ssh://git@github.com/user/foo#1.2.3'
     },
 
-    'git+ssh://git@github.com:user/foo#1.2.3': {
-      name: null,
-      type: 'git',
-      saveSpec: 'git+ssh://git@github.com/user/foo.git#1.2.3',
-      raw: 'git+ssh://git@github.com:user/foo#1.2.3'
-    },
-
     'git://github.com/user/foo': {
       name: null,
       type: 'git',

--- a/test/github.js
+++ b/test/github.js
@@ -52,6 +52,13 @@ require('tap').test('basic', function (t) {
       raw: 'git+ssh://git@github.com/user/foo#1.2.3'
     },
 
+    'git+ssh://git@github.com:user/foo#1.2.3': {
+      name: null,
+      type: 'git',
+      saveSpec: 'git+ssh://git@github.com/user/foo.git#1.2.3',
+      raw: 'git+ssh://git@github.com:user/foo#1.2.3'
+    },
+
     'git://github.com/user/foo': {
       name: null,
       type: 'git',


### PR DESCRIPTION
This supersedes #23 and fixes scp-style identifiers on non-'hosted' gits.