### PR TITLE
Allow /user/ and :user/ for git+[x] protocols

### DIFF
--- a/npa.js
+++ b/npa.js
@@ -229,6 +229,10 @@ function fromURL (res) {
       } else {
         setGitCommittish(res, urlparse.hash != null ? urlparse.hash.slice(1) : '')
         urlparse.protocol = urlparse.protocol.replace(/^git[+]/, '')
+        // support the :user/repo.git form
+        if (urlparse.pathname) {
+          urlparse.pathname = urlparse.pathname.replace(/^\/:/, '/')
+        }
         delete urlparse.hash
         res.fetchSpec = url.format(urlparse)
       }

--- a/test/basic.js
+++ b/test/basic.js
@@ -88,6 +88,16 @@ require('tap').test('basic', function (t) {
       rawSpec: '=v1.2.3'
     },
 
+    'git+https://git@notgithub.com:user/foo#1.2.3': {
+      name: null,
+      escapedName: null,
+      type: 'git',
+      saveSpec: 'git+https://git@notgithub.com:user/foo#1.2.3',
+      fetchSpec: 'https://git@notgithub.com/user/foo',
+      gitCommittish: '1.2.3',
+      raw: 'git+https://git@notgithub.com:user/foo#1.2.3'
+    },
+
     'git+ssh://git@notgithub.com/user/foo#1.2.3': {
       name: null,
       escapedName: null,


### PR DESCRIPTION
Currently, using the format git+https://git@notgithub.com:user/foo.git results in strange behavior.
This was working in previous releases of npm.