### PR TITLE
Set gitRange for git+ssh

### DIFF
--- a/npa.js
+++ b/npa.js
@@ -231,8 +231,8 @@ function fromURL (res) {
       res.type = 'git'
       const match = urlparse.protocol === 'git+ssh:' && matchGitScp(res.rawSpec)
       if (match) {
+        setGitCommittish(res, match.gitCommittish)
         res.fetchSpec = match.fetchSpec
-        res.gitCommittish = match.gitCommittish
       } else {
         setGitCommittish(res, urlparse.hash != null ? urlparse.hash.slice(1) : '')
         urlparse.protocol = urlparse.protocol.replace(/^git[+]/, '')


### PR DESCRIPTION
Fixed a problem where gitRange is not set when using `git+ssh`.
Example:
```
var npa = require("npm-package-arg");
try {
  var parsed = npa("git+ssh://git@github.com:npm/npm-package-arg.git#semver:^5.1.0");
  console.log(parsed.gitRange); // undefined
} catch (ex) {
  console.log(ex);
}
```

Should fix issues from https://github.com/npm/npm/issues/17621