### PR TITLE
Fix gitRange for git+ssh for private git

### DIFF
--- a/npa.js
+++ b/npa.js
@@ -231,8 +231,8 @@ function fromURL (res) {
       res.type = 'git'
       const match = urlparse.protocol === 'git+ssh:' && matchGitScp(res.rawSpec)
       if (match) {
+        setGitCommittish(res, match.gitCommittish)
         res.fetchSpec = match.fetchSpec
-        res.gitCommittish = match.gitCommittish
       } else {
         setGitCommittish(res, urlparse.hash != null ? urlparse.hash.slice(1) : '')
         urlparse.protocol = urlparse.protocol.replace(/^git[+]/, '')

--- a/test/basic.js
+++ b/test/basic.js
@@ -220,6 +220,18 @@ require('tap').test('basic', function (t) {
       raw: 'git+ssh://git@notgithub.com/user/foo#semver:^1.2.3'
     },
 
+    'git+ssh://git@notgithub.com:user/foo#semver:^1.2.3': {
+      name: null,
+      escapedName: null,
+      type: 'git',
+      hosted: null,
+      saveSpec: 'git+ssh://git@notgithub.com:user/foo#semver:^1.2.3',
+      fetchSpec: 'git@notgithub.com:user/foo',
+      gitCommittish: null,
+      gitRange: '^1.2.3',
+      raw: 'git+ssh://git@notgithub.com:user/foo#semver:^1.2.3'
+    },
+
     'git+ssh://git@github.com/user/foo#semver:^1.2.3': {
       name: null,
       escapedName: null,
@@ -229,6 +241,17 @@ require('tap').test('basic', function (t) {
       gitCommittish: null,
       gitRange: '^1.2.3',
       raw: 'git+ssh://git@github.com/user/foo#semver:^1.2.3'
+    },
+
+    'git+ssh://git@github.com:user/foo#semver:^1.2.3': {
+      name: null,
+      escapedName: null,
+      type: 'git',
+      saveSpec: 'git+ssh://git@github.com/user/foo.git#semver:^1.2.3',
+      fetchSpec: 'ssh://git@github.com/user/foo.git',
+      gitCommittish: null,
+      gitRange: '^1.2.3',
+      raw: 'git+ssh://git@github.com:user/foo#semver:^1.2.3'
     },
 
     'user/foo#semver:^1.2.3': {


### PR DESCRIPTION
Reopened the previous pull request: https://github.com/npm/npm-package-arg/pull/32
I haven't realized that git range works for hosted git like github.com but it doesn't for private git. Ex:

```
var npa = require("npm-package-arg");
try {
  var parsed = npa("git+ssh://git@github.com:npm/npm-package-arg.git#semver:~5.0.0");
  console.log(parsed.gitRange); // Works as expected: ~5.0.0
} catch (ex) {
  console.log(ex);
}
try {
  var parsed = npa("git+ssh://git@private.git.com:development/repositories.git#semver:~1.0.0");
  console.log(parsed.gitRange); // Dosen't work: undefined
} catch (ex) {
  console.log(ex);
}
```