### PR TITLE
fix windows git file urls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
+  - "12"
   - "10"
   - "8"
   - "6"
-  - "11"
 sudo: false
 script: "npm test"

--- a/npa.js
+++ b/npa.js
@@ -238,6 +238,11 @@ function fromURL (res) {
       } else {
         setGitCommittish(res, urlparse.hash != null ? urlparse.hash.slice(1) : '')
         urlparse.protocol = urlparse.protocol.replace(/^git[+]/, '')
+        if (urlparse.protocol === 'file:' && /^git\+file:\/\/[a-z]:/i.test(res.rawSpec)) {
+          // keep the drive letter : on windows file paths
+          urlparse.host += ':'
+          urlparse.hostname += ':'
+        }
         delete urlparse.hash
         res.fetchSpec = url.format(urlparse)
       }

--- a/npa.js
+++ b/npa.js
@@ -6,7 +6,11 @@ module.exports.Result = Result
 let url
 let HostedGit
 let semver
-let path
+let path_
+function path () {
+  if (!path_) path_ = require('path')
+  return path_
+}
 let validatePackageName
 let osenv
 
@@ -109,7 +113,6 @@ function Result (opts) {
   this.gitCommittish = opts.gitCommittish
   this.hosted = opts.hosted
 }
-Result.prototype = {}
 
 Result.prototype.setName = function (name) {
   if (!validatePackageName) validatePackageName = require('validate-npm-package-name')
@@ -152,8 +155,7 @@ const isAbsolutePath = /^[/]|^[A-Za-z]:/
 
 function resolvePath (where, spec) {
   if (isAbsolutePath.test(spec)) return spec
-  if (!path) path = require('path')
-  return path.resolve(where, spec)
+  return path().resolve(where, spec)
 }
 
 function isAbsolute (dir) {
@@ -180,8 +182,7 @@ function fromFile (res, where) {
     if (isAbsolute(spec)) {
       res.saveSpec = 'file:' + spec
     } else {
-      if (!path) path = require('path')
-      res.saveSpec = 'file:' + path.relative(where, res.fetchSpec)
+      res.saveSpec = 'file:' + path().relative(where, res.fetchSpec)
     }
   }
   return res

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "postrelease": "npm publish && git push --follow-tags",
     "pretest": "standard",
     "release": "standard-version -s",
-    "test": "tap -J --coverage test/*.js",
+    "test": "tap --100 -J --coverage test/*.js",
     "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
     "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
   },

--- a/test/basic.js
+++ b/test/basic.js
@@ -426,6 +426,15 @@ require('tap').test('basic', function (t) {
       raw: 'file:////path/to/foo'
     },
 
+    'http://insecure.com/foo.tgz': {
+      name: null,
+      escapedName: null,
+      type: 'remote',
+      saveSpec: 'http://insecure.com/foo.tgz',
+      fetchSpec: 'http://insecure.com/foo.tgz',
+      raw: 'http://insecure.com/foo.tgz'
+    },
+
     'https://server.com/foo.tgz': {
       name: null,
       escapedName: null,
@@ -466,8 +475,21 @@ require('tap').test('basic', function (t) {
   var objSpec = {name: 'foo', rawSpec: '1.2.3'}
   t.equal(npa(objSpec, '/whatnot').toString(), 'foo@1.2.3', 'parsed object')
 
+  objSpec.where = '/whatnot'
+  t.equal(npa(objSpec).toString(), 'foo@1.2.3', 'parsed object w/o where arg')
+
+  t.equal(npa('git+http://foo.com/bar').toString(),
+    'git+http://foo.com/bar', 'parsed git toString')
+
   objSpec = {raw: './foo/bar', where: '/here'}
   t.equal(npa(objSpec).fetchSpec, '/here/foo/bar', '`where` is reused')
+
+  var res = new npa.Result({name: 'bar', rawSpec: './foo/bar'})
+  t.equal(res.toString(), 'bar@./foo/bar', 'toString with only rawSpec')
+  res = new npa.Result({rawSpec: './x/y'})
+  t.equal(res.toString(), './x/y', 'toString with only rawSpec, no name')
+  res = new npa.Result({rawSpec: ''})
+  t.equal(res.toString(), '', 'toString with nothing')
 
   objSpec = {raw: './foo/bar', where: '/here'}
   t.equal(npa(objSpec, '/whatnot').fetchSpec, '/whatnot/foo/bar', '`where` arg overrides the one in the spec object')

--- a/test/invalid-url.js
+++ b/test/invalid-url.js
@@ -1,0 +1,5 @@
+const npa = require('../')
+const t = require('tap')
+t.throws(() => npa('foo@gopher://goodluckwiththat'), {
+  code: 'EUNSUPPORTEDPROTOCOL'
+})

--- a/test/windows.js
+++ b/test/windows.js
@@ -66,6 +66,21 @@ var cases = {
     rawSpec: '/foo/bar/baz',
     fetchSpec: '/foo/bar/baz',
     type: 'directory'
+  },
+  'foo@git+file://C:\\x\\y\\z': {
+    type: 'git',
+    registry: null,
+    where: null,
+    raw: 'foo@git+file://C:\\x\\y\\z',
+    name: 'foo',
+    escapedName: 'foo',
+    scope: null,
+    rawSpec: 'git+file://C:\\x\\y\\z',
+    saveSpec: 'git+file://C:\\x\\y\\z',
+    fetchSpec: 'file://c:/x/y/z',
+    gitRange: null,
+    gitCommittish: null,
+    hosted: null
   }
 }
 


### PR DESCRIPTION
This is why a lot of npm/cli tests fail on Windows.

Also, bumped test coverage up to 100%, because why not:?