### PR TITLE
fix: npa without any argument throws in npm

### DIFF
--- a/npa.js
+++ b/npa.js
@@ -20,6 +20,7 @@ const isURL = /^(?:git[+])?[a-z]+:/i
 const isFilename = /[.](?:tgz|tar.gz|tar)$/i
 
 function npa (arg, where) {
+  if (!arg) return {}
   let name
   let spec
   if (typeof arg === 'object') {

--- a/test/basic.js
+++ b/test/basic.js
@@ -531,5 +531,7 @@ require('tap').test('basic', function (t) {
   t.has(npa.resolve('foo', 'file:abc'), {type: 'directory', raw: 'foo@file:abc'}, 'npa.resolve sets raw right')
   t.has(npa('./path/to/thing/package@1.2.3/'), {name: null, type: 'directory'}, 'npa with path in @ in it')
   t.has(npa('path/to/thing/package@1.2.3'), {name: null, type: 'directory'}, 'npa w/o leading or trailing slash')
+
+  t.deepEqual(npa(), {}, 'no argument is given')
   t.end()
 })


### PR DESCRIPTION
# What / Why

- run “npm i” after linking a dependency that is in a git repository with ssh access
- this gives the error “npm ERR! Cannot read property ‘0’ of undefined”

## References

- https://npm.community/t/npm-install-fails-when-a-git-ssh-project-is-linked/9947
