### PR TITLE
feat(git): add support for ::subdir in #committish

### DIFF
--- a/npa.js
+++ b/npa.js
@@ -142,6 +142,11 @@ Result.prototype.toJSON = function () {
 }
 
 function setGitCommittish (res, committish) {
+  if (committish != null && committish.includes('::')) {
+    const parts = committish.split('::')
+    committish = parts[0]
+    res.gitSubdir = `/${parts[1]}`
+  }
   if (committish != null && committish.length >= 7 && committish.slice(0, 7) === 'semver:') {
     res.gitRange = decodeURIComponent(committish.slice(7))
     res.gitCommittish = null


### PR DESCRIPTION
More to do (docs and test, at least), but thought I'd pause for feedback:

# What / Why
For git URLs, allow the specification of a subdirectory within the given repository via the hash portion of the URL using the syntax: `#[COMMITTISH][::SUBDIR]`.  If `SUBDIR` is specified, the result object will have a new key `gitSubdir` with the value `/SUBDIR`, which can then be consumed by e.g. pacote (see References below for corresponding pacote changes).  The result object's `gitCommittish` and `gitRange` keys are unchanged from current behavior.

This feature will help npm provide improved support for "monorepos" or any git repository in which the `package.json` is not at the repository root.

## References
* Related to npm/npm#2974, npm/cli#528
* Corresponding pacote support (latest): https://github.com/sspiff/pacote/commit/8bd54618ee5a240bf4a82f90b852bf52f99363ee
* Corresponding pacote support (v9): https://github.com/sspiff/pacote/commit/5cb873948f1b8c56b0e6080306711ec9fe840cad