### PR TITLE
feat: validate version range

### DIFF
--- a/npa.js
+++ b/npa.js
@@ -92,6 +92,11 @@ function invalidTagName (name) {
   err.code = 'EINVALIDTAGNAME'
   return err
 }
+function invalidVersionRange (range) {
+  const err = new Error(`Invalid version range "${range}": Version may not contain spaces.`)
+  err.code = 'EINVALIDVERSIONRANGE'
+  return err
+}
 
 function Result (opts) {
   this.type = opts.type
@@ -290,6 +295,10 @@ function fromRegistry (res) {
   if (version) {
     res.type = 'version'
   } else if (range) {
+    if (!/^\S+$/g.test(spec)) {
+      throw invalidVersionRange(spec)
+    }
+
     res.type = 'range'
   } else {
     if (encodeURIComponent(spec) !== spec) {

--- a/test/basic.js
+++ b/test/basic.js
@@ -522,6 +522,10 @@ require('tap').test('basic', function (t) {
     npa('foo@npm:foo/bar')
   }, 'aliases only work for registry deps')
 
+  t.throws(() => {
+    npa('foo@npm:3.2. 1')
+  }, 'version may not contain spaces')
+
   t.has(npa.resolve('foo', '^1.2.3', '/test/a/b'), {type: 'range'}, 'npa.resolve')
   t.has(npa.resolve('foo', 'file:foo', '/test/a/b'), {type: 'directory', fetchSpec: '/test/a/b/foo'}, 'npa.resolve file:')
   t.has(npa.resolve('foo', '../foo/bar', '/test/a/b'), {type: 'directory'}, 'npa.resolve no protocol')


### PR DESCRIPTION
# What / Why
Typos in package.json may lead to hidden bugs.

## References
`"react": "^16.8. 0",`

`npm install` ends up installing

```
"react": {
  "version": "0.14.9",
  "resolved": "https://registry.npmjs.org/react/-/react-0.14.9.tgz",
...
```

This seems harmless but the typo is easy to miss and can lead to bugs during deployment.