### PR TITLE
fix: handle symlinking when root directory begins with a special char…

### DIFF
--- a/npa.js
+++ b/npa.js
@@ -171,7 +171,7 @@ function fromFile (res, where) {
 
   const spec = res.rawSpec.replace(/\\/g, '/')
     .replace(/^file:[/]*([A-Za-z]:)/, '$1') // drive name paths on windows
-    .replace(/^file:(?:[/]*([~./]))?/, '$1')
+    .replace(/^file:(?:[/]*(~\/|\.*\/|[/]))?/, '$1')
   if (/^~[/]/.test(spec)) {
     // this is needed for windows and for file:~/foo/bar
     if (!os) os = require('os')

--- a/test/basic.js
+++ b/test/basic.js
@@ -375,6 +375,24 @@ require('tap').test('basic', function (t) {
       raw: 'file:/~/path/to/foo'
     },
 
+    'file:/~path/to/foo': {
+      name: null,
+      escapedName: null,
+      type: 'directory',
+      saveSpec: 'file:/~path/to/foo',
+      fetchSpec: '/~path/to/foo',
+      raw: 'file:/~path/to/foo'
+    },
+
+    'file:/.path/to/foo': {
+      name: null,
+      escapedName: null,
+      type: 'directory',
+      saveSpec: 'file:/.path/to/foo',
+      fetchSpec: '/.path/to/foo',
+      raw: 'file:/.path/to/foo'
+    },
+
     'file:../path/to/foo': {
       name: null,
       escapedName: null,


### PR DESCRIPTION
This arose out of my investigation into https://github.com/npm/cli/issues/2447 
The file resolution for local paths beginning with `/~something` or `/.something` strips off the leading slash, meaning that the eventual resolved path is incorrect as it is incorrectly treated as not being an absolute path

I've added a couple of test cases to demonstrate the failing situations and altered the regexp replacement to only match `~` and `.` characters that are followed by a `/`

## References

Related to https://github.com/npm/cli/issues/2447
