### PR TITLE
fix: Fail on empty string ""

### DIFF
--- a/npa.js
+++ b/npa.js
@@ -48,8 +48,10 @@ function npa (arg, where) {
     const valid = validatePackageName(arg)
     if (valid.validForOldPackages) {
       name = arg
-    } else {
+    } else if (valid.validForNewPackages) {
       spec = arg
+    } else {
+      throw invalidPackageName(arg, valid)
     }
   }
   return resolve(name, spec, where, arg)

--- a/test/basic.js
+++ b/test/basic.js
@@ -542,6 +542,10 @@ require('tap').test('basic', function (t) {
     npa.resolve('invalid/name', '1.0.0')
   }, 'Invalid names throw errrors')
 
+  t.throws(function () {
+    npa('')
+  }, 'Empty names throw errrors')
+
   t.throws(() => {
     npa('foo@npm:bar@npm:baz')
   }, 'nested aliases not supported')


### PR DESCRIPTION
Not sure if this is the right place for this check, but too far down and the context is lost

Fixes npm/cli#3029

Signed-off-by: Marco Sirabella <marco@sirabella.org>