### PR TITLE
Make file: URLs (mostly) RFC 8909 compliant

### DIFF
--- a/test/windows.js
+++ b/test/windows.js
@@ -1,72 +1,81 @@
 global.FAKE_WINDOWS = true
 
-var npa = require('../npa.js')
-var test = require('tap').test
+const npa = require('../npa.js')
+const t = require('tap')
 
-var cases = {
+t.on('bailout', () => process.exit(1))
+
+const cases = {
   'C:\\x\\y\\z': {
     raw: 'C:\\x\\y\\z',
     scope: null,
     name: null,
     escapedName: null,
     rawSpec: 'C:\\x\\y\\z',
-    fetchSpec: 'C:/x/y/z',
+    fetchSpec: 'C:\\x\\y\\z',
     type: 'directory',
   },
+
   'foo@C:\\x\\y\\z': {
     raw: 'foo@C:\\x\\y\\z',
     scope: null,
     name: 'foo',
     escapedName: 'foo',
     rawSpec: 'C:\\x\\y\\z',
-    fetchSpec: 'C:/x/y/z',
+    fetchSpec: 'C:\\x\\y\\z',
     type: 'directory',
   },
+
   'foo@file:///C:\\x\\y\\z': {
     raw: 'foo@file:///C:\\x\\y\\z',
     scope: null,
     name: 'foo',
     escapedName: 'foo',
     rawSpec: 'file:///C:\\x\\y\\z',
-    fetchSpec: 'C:/x/y/z',
+    fetchSpec: 'C:\\x\\y\\z',
     type: 'directory',
   },
+
   'foo@file://C:\\x\\y\\z': {
     raw: 'foo@file://C:\\x\\y\\z',
     scope: null,
     name: 'foo',
     escapedName: 'foo',
     rawSpec: 'file://C:\\x\\y\\z',
-    fetchSpec: 'C:/x/y/z',
+    fetchSpec: 'C:\\x\\y\\z',
     type: 'directory',
   },
+
   'file:///C:\\x\\y\\z': {
     raw: 'file:///C:\\x\\y\\z',
     scope: null,
     name: null,
     escapedName: null,
     rawSpec: 'file:///C:\\x\\y\\z',
-    fetchSpec: 'C:/x/y/z',
+    fetchSpec: 'C:\\x\\y\\z',
     type: 'directory',
   },
+
   'file://C:\\x\\y\\z': {
     raw: 'file://C:\\x\\y\\z',
     scope: null,
     name: null,
     escapedName: null,
     rawSpec: 'file://C:\\x\\y\\z',
-    fetchSpec: 'C:/x/y/z',
+    fetchSpec: 'C:\\x\\y\\z',
     type: 'directory',
   },
+
   'foo@/foo/bar/baz': {
     raw: 'foo@/foo/bar/baz',
     scope: null,
     name: 'foo',
     escapedName: 'foo',
     rawSpec: '/foo/bar/baz',
-    fetchSpec: '/foo/bar/baz',
+    fetchSpec: 'C:\\foo\\bar\\baz',
     type: 'directory',
   },
+
   'foo@git+file://C:\\x\\y\\z': {
     type: 'git',
     registry: null,
@@ -84,10 +93,10 @@ var cases = {
   },
 }
 
-test('parse a windows path', function (t) {
+t.test('parse a windows path', function (t) {
   Object.keys(cases).forEach(function (c) {
-    var expect = cases[c]
-    var actual = npa(c)
+    const expect = cases[c]
+    const actual = npa(c, 'C:\\test\\path')
     t.has(actual, expect, c)
   })
   t.end()


### PR DESCRIPTION
The change made in e8c4301a23afb4e39778b4cb048631bf729cb38b was
reasonable, but had the unfortunate side effect of breaking backwards
compatibility for urls like 'file://.'.

Further investigation showed that we really weren't complying with RFC
8909's specifications regarding file: URLs, and even further
investigation than that showed that it'll be a breaking change if we do.

This patch isolates the non-8909 compliance bits into a single block
that can be disabled with an environment variable and easily removed
when we are willing to take on that breaking change.  The bug fixed by
the commit that broke file://. is still fixed, and we obey RFC8909
otherwise.

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
