### PR TITLE
add function to return pacakge purl

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,16 @@ included then the default is `latest`.
 
 **Throws** if the package name is invalid, a dist-tag is invalid or a URL's protocol is not supported.
 
+### var purl = npa.toPurl(*arg*, *reg*)
+
+Returns the [purl (package URL)](https://github.com/package-url/purl-spec) form of the given pacakge name/spec.
+
+* *arg* - A package/version string. For example: `foo@1.0.0` or `@bar/foo@2.0.0-alpha.1`.
+* *reg* - Optionally the URL to the package registry. If not specified, assumes the default
+`https://registry.npmjs.org`.
+
+**Throws** if the package name is invalid, or the supplied arg can't be resolved to a purl.
+
 ## RESULT OBJECT
 
 The objects that are returned by npm-package-arg contain the following

--- a/test/purl.js
+++ b/test/purl.js
@@ -1,0 +1,46 @@
+'use strict'
+var test = require('tap').test
+var npa = require('..')
+
+test('toPurl - valid', function (t) {
+  // Unscoped package
+  t.equal(npa.toPurl('foo@1.2.3'), 'pkg:npm/foo@1.2.3')
+
+  // Scoped package
+  t.equal(
+    npa.toPurl('@foo/bar@1.2.3-alpha.1'),
+    'pkg:npm/%40foo/bar@1.2.3-alpha.1')
+
+  // Non-default registry
+  t.equal(
+    npa.toPurl({ name: '@foo/bar', rawSpec: '1.0.0' }, 'https://npm.pkg.github.com'),
+    'pkg:npm/%40foo/bar@1.0.0?repository_url=https://npm.pkg.github.com'
+  )
+
+  // Default registry
+  t.equal(
+    npa.toPurl({ name: '@foo/bar', rawSpec: '1.0.0' }, 'https://registry.npmjs.org'),
+    'pkg:npm/%40foo/bar@1.0.0'
+  )
+
+  t.end()
+})
+
+test('toPurl - invalid', function (t) {
+  // Invalid version
+  t.throws(() => npa.toPurl({ name: 'foo/bar', rawSpec: '1.0.0' }), {
+    code: 'EINVALIDPACKAGENAME',
+  })
+
+  // Invalid version
+  t.throws(() => npa.toPurl('foo@a.b.c'), {
+    code: 'EINVALIDPURLTYPE',
+  })
+
+  // Invalid type
+  t.throws(() => npa.toPurl('git+ssh://git@github.com/user/foo#1.2.3'), {
+    code: 'EINVALIDPURLTYPE',
+  })
+
+  t.end()
+})


### PR DESCRIPTION
Adds a new `toPurl` function which translates a package name/version into a its [purl](https://github.com/package-url/purl-spec) (Package URL) form.
<!-- What / Why -->

<!-- Describe the request in detail. What it does and why it's being changed. -->


```node
> npa.toPurl('foo', '0.1.0')
'pkg:npm/foo@0.1.0'

> npa.toPurl('@foo/bar', '1.0.0-alpha.1')
'pkg:npm/%40foo/bar@1.0.0-alpha.1'

> npa.toPurl('foo:bar', 'a.b.c')
Uncaught:
Error: Invalid package name "foo:bar" of package "foo:bar@a.b.c": name can only contain URL-friendly characters.
    at invalidPackageName (/Users/bdehamer/dev/npm-package-arg/lib/npa.js:110:15)
    at Function.toPurl (/Users/bdehamer/dev/npm-package-arg/lib/npa.js:96:11) {
  code: 'EINVALIDPACKAGENAME'
}
```