### PR TITLE
feat: support yarn alias

### DIFF
--- a/lib/npa.js
+++ b/lib/npa.js
@@ -69,7 +69,7 @@ function resolve (name, spec, where, arg) {
 
   if (spec && (isFilespec.test(spec) || /^file:/i.test(spec))) {
     return fromFile(res, where)
-  } else if (spec && /^npm:/i.test(spec)) {
+  } else if (spec && /^(npm|yarn):/i.test(spec)) {
     return fromAlias(res, where)
   }
 
@@ -391,7 +391,8 @@ function fromURL (res) {
 }
 
 function fromAlias (res, where) {
-  const subSpec = npa(res.rawSpec.substr(4), where)
+  const specDetail = /^yarn:/i.test(res.rawSpec) ? res.rawSpec.substr(5) : res.rawSpec.substr(4)
+  const subSpec = npa(specDetail, where)
   if (subSpec.type === 'alias') {
     throw new Error('nested aliases not supported')
   }


### PR DESCRIPTION
Can we support yarn alias in the package `npm-package-arg` ? thank you.