### PR TITLE
fix: throw an err when alias is without name

### DIFF
--- a/lib/npa.js
+++ b/lib/npa.js
@@ -380,6 +380,10 @@ function fromAlias (res, where) {
     throw new Error('aliases only work for registry deps')
   }
 
+  if (!subSpec.name) {
+    throw new Error('aliases must have a name')
+  }
+
   res.subSpec = subSpec
   res.registry = true
   res.type = 'alias'

--- a/test/basic.js
+++ b/test/basic.js
@@ -693,6 +693,10 @@ t.test('basic', function (t) {
   }, 'nested aliases not supported')
 
   t.throws(() => {
+    npa('foo@npm:')
+  }, 'aliases must have a name')
+
+  t.throws(() => {
     npa('foo@npm:foo/bar')
   }, 'aliases only work for registry deps')
 


### PR DESCRIPTION
throws error when alias spec is without name. e.g. ( foo@npm: )
Fixes: https://github.com/npm/cli/issues/7590