### PR TITLE
ci test - do not merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # npm-package-arg
 
+CI TEST
+
 [![Build Status](https://img.shields.io/github/actions/workflow/status/npm/npm-package-arg/ci.yml?branch=main)](https://github.com/npm/npm-package-arg)
 
 Parses package name and specifier passed to commands like `npm install` or


### PR DESCRIPTION
Not sure if CI images have even been updated yet, seeing if the [path.join](https://nodejs.org/en/blog/vulnerability/january-2025-security-releases#path-traversal-by-drive-name-in-windows-environment-cve-2025-23084---medium) changes in node affect CI.