### PR TITLE
test: Add test case for regression in npm/cli (#203)

### DIFF
--- a/test/basic.js
+++ b/test/basic.js
@@ -756,6 +756,17 @@ t.test('file: spec with non URI compatible components', t => {
   t.end()
 })
 
+t.test('file: spec with encoded URI components', t => {
+  t.has(normalizePaths(npa('file:/test_%23dir')), {
+    type: 'directory',
+    name: null,
+    rawSpec: 'file:/test_%23dir',
+    fetchSpec: '/test_#dir',
+    saveSpec: 'file:/test_#dir',
+  })
+  t.end()
+})
+
 t.test('directory cwd has non URI compatible components', t => {
   // eslint-disable-next-line max-len
   const where = '/tmp/ !"$%&\'()*+,-.0123456789:;<=>@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~'


### PR DESCRIPTION
I looked into #203. What's happening is that Arborist is providing npa with a path where the `#` character has already been URL-encoded, like this:

```
npa('file:/test_%23dir')
```

Prior to #200, the result looked like this:

```
{
  type: 'directory',
  name: null,
  rawSpec: 'file:/test_%23dir',
  fetchSpec: '/test_#dir',
  saveSpec: 'file:/test_#dir',
}
```

After #200, the result looks like this:

```
{
  type: 'directory',
  name: null,
  rawSpec: 'file:/test_%23dir',
  fetchSpec: '/test_%23dir',
  saveSpec: 'file:/test_%23dir',
}
```

I'm not sure what the best fix for this is, but I hope this (failing) test case helps. I believe the key change is around this line: https://github.com/npm/npm-package-arg/blob/fbbf22ef99ece449428fee761ae8950c08bc2cbf/lib/npa.js#L316

cc @wraithgar @reggi 