### PR TITLE
feat: add JSR protocol support for package specifiers

### DIFF
--- a/lib/npa.js
+++ b/lib/npa.js
@@ -78,6 +78,13 @@ function isAliasSpec (spec) {
   return spec.toLowerCase().startsWith('npm:')
 }
 
+function isJsrSpec (spec) {
+  if (!spec) {
+    return false
+  }
+  return spec.toLowerCase().startsWith('jsr:')
+}
+
 function resolve (name, spec, where, arg) {
   const res = new Result({
     raw: arg,
@@ -98,6 +105,8 @@ function resolve (name, spec, where, arg) {
     return fromFile(res, where)
   } else if (isAliasSpec(spec)) {
     return fromAlias(res, where)
+  } else if (isJsrSpec(spec)) {
+    return fromJsr(res)
   }
 
   const hosted = HostedGit.fromUrl(spec, {
@@ -450,6 +459,62 @@ function fromAlias (res, where) {
   res.type = 'alias'
   res.saveSpec = null
   res.fetchSpec = null
+  return res
+}
+
+function fromJsr (res) {
+  // Remove 'jsr:' prefix
+  const jsrSpec = res.rawSpec.substr(4)
+
+  // Parse the JSR specifier to extract name and version
+  // JSR format: @scope/name or @scope/name@version
+  const nameEnd = jsrSpec.indexOf('@', 1) // Skip the leading @ in @scope
+  const jsrName = nameEnd > 0 ? jsrSpec.slice(0, nameEnd) : jsrSpec
+  const versionSpec = nameEnd > 0 ? jsrSpec.slice(nameEnd + 1) : ''
+
+  // Validate that JSR package is scoped
+  if (!jsrName.startsWith('@') || !jsrName.includes('/')) {
+    throw new Error(`JSR packages must be scoped (e.g., jsr:@scope/name): ${res.raw}`)
+  }
+
+  // Validate the package name
+  const valid = validatePackageName(jsrName)
+  if (!valid.validForOldPackages) {
+    throw invalidPackageName(jsrName, valid, res.raw)
+  }
+
+  // Transform @scope/name to @jsr/scope__name
+  // Extract scope and package name
+  const scopeEnd = jsrName.indexOf('/')
+  const scope = jsrName.slice(1, scopeEnd) // Remove leading @ from scope
+  const packageName = jsrName.slice(scopeEnd + 1)
+  const transformedName = `@jsr/${scope}__${packageName}`
+
+  // Set the transformed name
+  res.setName(transformedName)
+  res.registry = true
+
+  // Preserve the original JSR spec for saving
+  res.saveSpec = `jsr:${jsrName}${versionSpec ? '@' + versionSpec : ''}`
+
+  // Determine the type based on version specifier
+  const spec = versionSpec || '*'
+  res.rawSpec = spec
+  res.fetchSpec = spec
+
+  const version = semver.valid(spec, true)
+  const range = semver.validRange(spec, true)
+  if (version) {
+    res.type = 'version'
+  } else if (range) {
+    res.type = 'range'
+  } else {
+    if (encodeURIComponent(spec) !== spec) {
+      throw invalidTagName(spec, res.raw)
+    }
+    res.type = 'tag'
+  }
+
   return res
 }
 

--- a/lib/npa.js
+++ b/lib/npa.js
@@ -82,7 +82,7 @@ function isJsrSpec (spec) {
   if (!spec) {
     return false
   }
-  return spec.toLowerCase().startsWith('jsr:')
+  return spec.startsWith('jsr:')
 }
 
 function resolve (name, spec, where, arg) {
@@ -464,7 +464,7 @@ function fromAlias (res, where) {
 
 function fromJsr (res, where) {
   // Remove 'jsr:' prefix
-  const jsrSpec = res.rawSpec.substr(4)
+  const jsrSpec = res.rawSpec.slice(4)
 
   // Parse the JSR specifier to extract name and version
   // JSR format: @scope/name or @scope/name@version

--- a/lib/npa.js
+++ b/lib/npa.js
@@ -106,7 +106,7 @@ function resolve (name, spec, where, arg) {
   } else if (isAliasSpec(spec)) {
     return fromAlias(res, where)
   } else if (isJsrSpec(spec)) {
-    return fromJsr(res)
+    return fromJsr(res, where)
   }
 
   const hosted = HostedGit.fromUrl(spec, {
@@ -462,58 +462,42 @@ function fromAlias (res, where) {
   return res
 }
 
-function fromJsr (res) {
+function fromJsr (res, where) {
   // Remove 'jsr:' prefix
   const jsrSpec = res.rawSpec.substr(4)
 
   // Parse the JSR specifier to extract name and version
   // JSR format: @scope/name or @scope/name@version
-  const nameEnd = jsrSpec.indexOf('@', 1) // Skip the leading @ in @scope
-  const jsrName = nameEnd > 0 ? jsrSpec.slice(0, nameEnd) : jsrSpec
-  const versionSpec = nameEnd > 0 ? jsrSpec.slice(nameEnd + 1) : ''
+  const versionIndex = jsrSpec.indexOf('@', 1)
+  const packagePart = versionIndex > 0 ? jsrSpec.slice(0, versionIndex) : jsrSpec
 
   // Validate that JSR package is scoped
-  if (!jsrName.startsWith('@') || !jsrName.includes('/')) {
+  if (!packagePart.startsWith('@') || !packagePart.includes('/')) {
     throw new Error(`JSR packages must be scoped (e.g., jsr:@scope/name): ${res.raw}`)
   }
 
-  // Validate the package name
-  const valid = validatePackageName(jsrName)
-  if (!valid.validForOldPackages) {
-    throw invalidPackageName(jsrName, valid, res.raw)
+  const subSpec = npa(jsrSpec, where)
+
+  // Validate that it was parsed as a registry dependency
+  if (!subSpec.registry) {
+    throw new Error('JSR packages must be registry dependencies')
   }
 
   // Transform @scope/name to @jsr/scope__name
   // Extract scope and package name
-  const scopeEnd = jsrName.indexOf('/')
-  const scope = jsrName.slice(1, scopeEnd) // Remove leading @ from scope
-  const packageName = jsrName.slice(scopeEnd + 1)
-  const transformedName = `@jsr/${scope}__${packageName}`
+  const originalScope = subSpec.scope.slice(1) // Remove leading @ from scope
+  const packageName = subSpec.name.slice(subSpec.scope.length + 1)
+  const transformedName = `@jsr/${originalScope}__${packageName}`
 
-  // Set the transformed name
+  // Set the transformed name and copy properties from subSpec
   res.setName(transformedName)
   res.registry = true
+  res.type = subSpec.type
+  res.fetchSpec = subSpec.fetchSpec
+  res.rawSpec = subSpec.rawSpec
 
-  // Preserve the original JSR spec for saving
-  res.saveSpec = `jsr:${jsrName}${versionSpec ? '@' + versionSpec : ''}`
-
-  // Determine the type based on version specifier
-  const spec = versionSpec || '*'
-  res.rawSpec = spec
-  res.fetchSpec = spec
-
-  const version = semver.valid(spec, true)
-  const range = semver.validRange(spec, true)
-  if (version) {
-    res.type = 'version'
-  } else if (range) {
-    res.type = 'range'
-  } else {
-    if (encodeURIComponent(spec) !== spec) {
-      throw invalidTagName(spec, res.raw)
-    }
-    res.type = 'tag'
-  }
+  // Preserve original JSR spec for saving
+  res.saveSpec = res.raw
 
   return res
 }

--- a/test/jsr.js
+++ b/test/jsr.js
@@ -171,13 +171,22 @@ t.test('JSR Result object passthrough', t => {
   t.end()
 })
 
-t.test('JSR case insensitivity', t => {
-  const res1 = npa('jsr:@std/testing')
-  const res2 = npa('JSR:@std/testing')
-  const res3 = npa('JsR:@std/testing')
+t.test('JSR case sensitivity', t => {
+  const res = npa('jsr:@std/testing')
 
-  t.equal(res1.name, '@jsr/std__testing', 'lowercase jsr: works')
-  t.equal(res2.name, '@jsr/std__testing', 'uppercase JSR: works')
-  t.equal(res3.name, '@jsr/std__testing', 'mixed case JsR: works')
+  t.equal(res.name, '@jsr/std__testing', 'lowercase jsr: works')
+
+  t.throws(
+    () => npa('JSR:@std/testing'),
+    /Unsupported URL Type/,
+    'throws error when package is parsed as unsupported URL type'
+  )
+
+  t.throws(
+    () => npa('JsR:@std/testing'),
+    /Unsupported URL Type/,
+    'throws error when package is parsed as unsupported URL type'
+  )
+
   t.end()
 })

--- a/test/jsr.js
+++ b/test/jsr.js
@@ -1,0 +1,183 @@
+const t = require('tap')
+const npa = require('..')
+
+t.test('JSR specifiers', t => {
+  const tests = {
+    'jsr:@std/testing': {
+      name: '@jsr/std__testing',
+      escapedName: '@jsr%2fstd__testing',
+      scope: '@jsr',
+      type: 'range',
+      registry: true,
+      saveSpec: 'jsr:@std/testing',
+      fetchSpec: '*',
+      raw: 'jsr:@std/testing',
+      rawSpec: '*',
+    },
+
+    'jsr:@std/testing@1.0.0': {
+      name: '@jsr/std__testing',
+      escapedName: '@jsr%2fstd__testing',
+      scope: '@jsr',
+      type: 'version',
+      registry: true,
+      saveSpec: 'jsr:@std/testing@1.0.0',
+      fetchSpec: '1.0.0',
+      raw: 'jsr:@std/testing@1.0.0',
+      rawSpec: '1.0.0',
+    },
+
+    'jsr:@std/testing@^1.0.0': {
+      name: '@jsr/std__testing',
+      escapedName: '@jsr%2fstd__testing',
+      scope: '@jsr',
+      type: 'range',
+      registry: true,
+      saveSpec: 'jsr:@std/testing@^1.0.0',
+      fetchSpec: '^1.0.0',
+      raw: 'jsr:@std/testing@^1.0.0',
+      rawSpec: '^1.0.0',
+    },
+
+    'jsr:@std/testing@~1.2.3': {
+      name: '@jsr/std__testing',
+      escapedName: '@jsr%2fstd__testing',
+      scope: '@jsr',
+      type: 'range',
+      registry: true,
+      saveSpec: 'jsr:@std/testing@~1.2.3',
+      fetchSpec: '~1.2.3',
+      raw: 'jsr:@std/testing@~1.2.3',
+      rawSpec: '~1.2.3',
+    },
+
+    'jsr:@std/testing@latest': {
+      name: '@jsr/std__testing',
+      escapedName: '@jsr%2fstd__testing',
+      scope: '@jsr',
+      type: 'tag',
+      registry: true,
+      saveSpec: 'jsr:@std/testing@latest',
+      fetchSpec: 'latest',
+      raw: 'jsr:@std/testing@latest',
+      rawSpec: 'latest',
+    },
+
+    'jsr:@sxzz/tsdown': {
+      name: '@jsr/sxzz__tsdown',
+      escapedName: '@jsr%2fsxzz__tsdown',
+      scope: '@jsr',
+      type: 'range',
+      registry: true,
+      saveSpec: 'jsr:@sxzz/tsdown',
+      fetchSpec: '*',
+      raw: 'jsr:@sxzz/tsdown',
+      rawSpec: '*',
+    },
+
+    'jsr:@sxzz/tsdown@2.0.0': {
+      name: '@jsr/sxzz__tsdown',
+      escapedName: '@jsr%2fsxzz__tsdown',
+      scope: '@jsr',
+      type: 'version',
+      registry: true,
+      saveSpec: 'jsr:@sxzz/tsdown@2.0.0',
+      fetchSpec: '2.0.0',
+      raw: 'jsr:@sxzz/tsdown@2.0.0',
+      rawSpec: '2.0.0',
+    },
+
+    'jsr:@oak/oak@>=12.0.0 <13.0.0': {
+      name: '@jsr/oak__oak',
+      escapedName: '@jsr%2foak__oak',
+      scope: '@jsr',
+      type: 'range',
+      registry: true,
+      saveSpec: 'jsr:@oak/oak@>=12.0.0 <13.0.0',
+      fetchSpec: '>=12.0.0 <13.0.0',
+      raw: 'jsr:@oak/oak@>=12.0.0 <13.0.0',
+      rawSpec: '>=12.0.0 <13.0.0',
+    },
+  }
+
+  Object.keys(tests).forEach(arg => {
+    t.test(arg, t => {
+      const res = npa(arg)
+      t.ok(res instanceof npa.Result, `${arg} is a result`)
+      Object.keys(tests[arg]).forEach(key => {
+        t.match(res[key], tests[arg][key], `${arg} [${key}]`)
+      })
+      t.end()
+    })
+  })
+
+  t.end()
+})
+
+t.test('JSR validation errors', t => {
+  t.test('unscoped package name', t => {
+    t.throws(
+      () => npa('jsr:unscoped'),
+      /JSR packages must be scoped/,
+      'throws error for unscoped JSR package'
+    )
+    t.end()
+  })
+
+  t.test('scope only, no package name', t => {
+    t.throws(
+      () => npa('jsr:@scopeonly'),
+      /JSR packages must be scoped/,
+      'throws error for scope without package name'
+    )
+    t.end()
+  })
+
+  t.test('invalid package name characters', t => {
+    t.throws(
+      () => npa('jsr:@scope/in valid'),
+      /Invalid package name/,
+      'throws error for invalid package name with spaces'
+    )
+    t.end()
+  })
+
+  t.test('invalid tag name with special characters', t => {
+    t.throws(
+      () => npa('jsr:@std/testing@tag with spaces'),
+      /Invalid tag name/,
+      'throws error for tag with invalid characters'
+    )
+    t.end()
+  })
+
+  t.end()
+})
+
+t.test('JSR with Result.toString()', t => {
+  const res = npa('jsr:@std/testing@1.0.0')
+  t.equal(
+    res.toString(),
+    '@jsr/std__testing@jsr:@std/testing@1.0.0',
+    'toString includes saveSpec'
+  )
+  t.end()
+})
+
+t.test('JSR Result object passthrough', t => {
+  const res = npa('jsr:@std/testing')
+  const res2 = npa(res)
+  t.equal(res, res2, 'passing Result object returns same Result')
+  t.end()
+})
+
+t.test('JSR case insensitivity', t => {
+  const res1 = npa('jsr:@std/testing')
+  const res2 = npa('JSR:@std/testing')
+  const res3 = npa('JsR:@std/testing')
+
+  t.equal(res1.name, '@jsr/std__testing', 'lowercase jsr: works')
+  t.equal(res2.name, '@jsr/std__testing', 'uppercase JSR: works')
+  t.equal(res3.name, '@jsr/std__testing', 'mixed case JsR: works')
+  t.end()
+})

--- a/test/jsr.js
+++ b/test/jsr.js
@@ -136,8 +136,8 @@ t.test('JSR validation errors', t => {
   t.test('invalid package name characters', t => {
     t.throws(
       () => npa('jsr:@scope/in valid'),
-      /Invalid package name/,
-      'throws error for invalid package name with spaces'
+      /JSR packages must be registry dependencies/,
+      'throws error when package is parsed as non-registry (e.g., directory)'
     )
     t.end()
   })


### PR DESCRIPTION
**Motivation**

Given that JSR is an MIT-licensed open-source solution and is already supported by other package managers such as Volt and pnpm, I believe npm should also adopt this feature to maintain consistency within the JavaScript ecosystem and provide a seamless user experience.

**Current Behavior**

Before this change, installing JSR packages is possible by adding the following to the `package.json`:

```json
{
  "dependencies": {
    "@scope/package": "npm:@jsr/scope__package@1.0.0"
  }
}
```

This approach is rather messy and relies on the [npm compatibility registry API](https://jsr.io/docs/api#npm-compatibility-registry-api) to download packages from the JSR registry.

**Proposed Solution**

The proposed solution would be to handle installing packages from JSR natively. Installing a package from JSR would be simplified to:

```bash
npm i jsr:@scope/package
```

Which then installs a JSR package into the `package.json` as follows:

```json
{
  "dependencies": {
    "@scope/package": "jsr:@scope/package@1.0.0"
  }
}
```

**Reference**

This implementation is based on the approach discussed in https://github.com/pnpm/pnpm/issues/8941.