### PR TITLE
feat: support github and jsr aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,9 @@ keys:
   * `file` - A local `.tar.gz`, `.tar` or `.tgz` file.
   * `directory` - A local directory.
   * `remote` - An http url (presumably to a tgz)
-  * `alias` - A specifier with an alias, like `myalias@npm:foo@1.2.3`
+  * `alias` - A specifier that aliases another registry package, like
+    `myalias@npm:foo@1.2.3`, `myalias@jsr:@scope/pkg@1.2.3`, or
+    `myalias@github:@owner/pkg@1.2.3`. See [Alias specifiers](#alias-specifiers).
 * `registry` - If true this specifier refers to a resource hosted on a
   registry.  This is true for `tag`, `version` and `range` types.
 * `name` - If known, the `name` field expected in the resulting pkg.
@@ -94,6 +96,46 @@ keys:
   `npa.resolve(name, spec)` then this will be `name + '@' + spec`.
 * `subSpec` - If `type === 'alias'`, this is a Result Object for parsing the
   target specifier for the alias.
+* `aliasType` - When `type === 'alias'`, one of `'npm'`, `'jsr'`, or
+  `'github'`, identifying which alias prefix the specifier used. `undefined`
+  on non-alias results.
+* `jsrName` - When `aliasType === 'jsr'`, the original scoped JSR package
+  name (e.g. `@scope/pkg`) as written by the user. `subSpec.name` is the
+  remapped `@jsr/<scope>__<name>` form used to fetch from the registry.
+
+## ALIAS SPECIFIERS
+
+Aliases install one package under a different name. Three prefixes are
+recognized, each resolving to a registry dependency:
+
+* `<alias>@npm:<name>[@<version>]` — aliases within the configured npm
+  registry. `npm-alias@npm:express@4` installs `express` as `npm-alias`.
+* `<alias>@jsr:@<scope>/<name>[@<version>]` — aliases a JSR package. The
+  scoped name is remapped to `@jsr/<scope>__<name>` to match JSR's npm
+  compatibility registry; the fetch is routed by the standard
+  `@jsr:registry=https://npm.jsr.io/` scope config.
+* `<alias>@github:@<owner>/<name>[@<version>]` — aliases a GitHub Packages
+  npm package. The scoped name is used as-is; the fetch is routed by the
+  standard `@<owner>:registry=https://npm.pkg.github.com/` scope config.
+
+For `jsr:` and `github:`, a bare-version form is also accepted when the
+alias name is itself a scoped package name — e.g.
+`@scope/foo@jsr:^1.0.0` uses `@scope/foo` as the JSR package name.
+
+### GitHub git-shortcut compatibility
+
+`github:<owner>/<repo>` is `hosted-git-info`'s long-standing shortcut for a
+GitHub git repository. It is **not** treated as an alias — it continues to
+resolve to `type: 'git'`. This applies to:
+
+* `github:owner/repo`
+* `github:owner/repo#<committish>`
+* `github:owner/repo#semver:<range>`
+* `foo@github:owner/repo` and variants above with an alias on the left
+
+The `github:` alias path is only taken when the body is unambiguously not a
+git shortcut: either a scoped package name (`github:@owner/pkg…`) or a bare
+version selector paired with a scoped alias (`@scope/pkg@github:…`).
 
 ## SAVE SPECS
 

--- a/lib/npa.js
+++ b/lib/npa.js
@@ -69,11 +69,50 @@ function isFileSpec (spec) {
   return isPosixFile.test(spec)
 }
 
-function isAliasSpec (spec) {
+const aliasPrefixes = ['npm:', 'jsr:', 'github:']
+
+function aliasPrefix (spec) {
   if (!spec) {
+    return null
+  }
+  const lower = spec.toLowerCase()
+  for (const prefix of aliasPrefixes) {
+    if (lower.startsWith(prefix)) {
+      return prefix
+    }
+  }
+  return null
+}
+
+// `hosted-git-info` treats `github:<owner>/<repo>` as a shorthand for a GitHub
+// git repository. We only claim `github:` as an alias when the body is
+// unambiguously not a git shortcut — either a scoped package name
+// (`github:@<owner>/<name>[@<version>]`) or a bare version selector paired
+// with a scoped alias (`<@scope/name>@github:<version>`). Anything else —
+// `github:owner/repo`, `github:owner/repo#main`, `github:abcd1234`, or a
+// bare version without a scoped alias — is deferred to hosted-git-info so
+// existing git-shortcut usage keeps working.
+function isGithubAliasSpec (spec, name) {
+  const body = spec.slice('github:'.length)
+  if (body.startsWith('@')) {
+    return true
+  }
+  // bare version form requires a scoped alias name and must not look like a path
+  if (!name || !name.startsWith('@') || body.includes('/')) {
     return false
   }
-  return spec.toLowerCase().startsWith('npm:')
+  return true
+}
+
+function isAliasSpec (spec, name) {
+  const prefix = aliasPrefix(spec)
+  if (!prefix) {
+    return false
+  }
+  if (prefix === 'github:') {
+    return isGithubAliasSpec(spec, name)
+  }
+  return true
 }
 
 function resolve (name, spec, where, arg) {
@@ -94,7 +133,7 @@ function resolve (name, spec, where, arg) {
 
   if (isFileSpec(spec)) {
     return fromFile(res, where)
-  } else if (isAliasSpec(spec)) {
+  } else if (isAliasSpec(spec, name)) {
     return fromAlias(res, where)
   }
 
@@ -173,6 +212,8 @@ class Result {
     this.gitCommittish = opts.gitCommittish
     this.gitSubdir = opts.gitSubdir
     this.hosted = opts.hosted
+    this.aliasType = opts.aliasType
+    this.jsrName = opts.jsrName
   }
 
   // TODO move this to a getter/setter in a semver major
@@ -429,23 +470,121 @@ function fromURL (res) {
   return res
 }
 
-function fromAlias (res, where) {
-  const subSpec = npa(res.rawSpec.substr(4), where)
+// JSR publishes its packages to a registry that speaks the npm protocol, but
+// remaps `@<scope>/<name>` to `@jsr/<scope>__<name>`. This mirrors
+// pnpm's `jsrToNpmPackageName` so the resulting subSpec is a normal
+// registry entry under the `@jsr` scope, and npm's existing
+// `@jsr:registry=...` scope-config mechanism handles registry selection.
+function jsrToNpmPackageName (jsrPkgName, raw) {
+  if (jsrPkgName[0] !== '@') {
+    const err = new Error(
+      `Package names from JSR must have a scope: ${raw}`
+    )
+    err.code = 'EMISSINGJSRSCOPE'
+    throw err
+  }
+  const sepIndex = jsrPkgName.indexOf('/')
+  if (sepIndex === -1 || sepIndex === jsrPkgName.length - 1) {
+    const err = new Error(
+      `Invalid JSR package name "${jsrPkgName}" of package "${raw}"`
+    )
+    err.code = 'EINVALIDJSRNAME'
+    throw err
+  }
+  const scope = jsrPkgName.substring(1, sepIndex)
+  const name = jsrPkgName.substring(sepIndex + 1)
+  return `@jsr/${scope}__${name}`
+}
+
+// Parses the body of a `jsr:` or `github:` alias into { pkgName, versionSelector }.
+// Accepted forms (matching pnpm's parsers):
+//   <prefix>:@<scope>/<name>
+//   <prefix>:@<scope>/<name>@<version_selector>
+//   <prefix>:<version_selector>      — only when an alias name is provided
+function parseScopedAliasBody (body, aliasName, raw, kind) {
+  if (body[0] === '@') {
+    const at = body.lastIndexOf('@')
+    if (at === 0) {
+      return { pkgName: body, versionSelector: null }
+    }
+    return {
+      pkgName: body.substring(0, at),
+      versionSelector: body.substring(at + 1),
+    }
+  }
+  if (!aliasName) {
+    const err = new Error(
+      `${kind} alias "${raw}" is missing a package name`
+    )
+    err.code = 'EINVALIDALIAS'
+    throw err
+  }
+  return { pkgName: aliasName, versionSelector: body }
+}
+
+// Invariants every alias subSpec must satisfy, regardless of prefix: it must
+// be a registry dep, it must have a name, and it must not itself be an alias
+// (aliases cannot nest).
+function validateAliasSubSpec (subSpec) {
   if (subSpec.type === 'alias') {
     throw new Error('nested aliases not supported')
   }
-
   if (!subSpec.registry) {
     throw new Error('aliases only work for registry deps')
   }
-
   if (!subSpec.name) {
     throw new Error('aliases must have a name')
+  }
+}
+
+function fromNpmAlias (res, where) {
+  const subSpec = npa(res.rawSpec.substr('npm:'.length), where)
+  validateAliasSubSpec(subSpec)
+  return subSpec
+}
+
+function fromJsrAlias (res, where) {
+  const body = res.rawSpec.substr('jsr:'.length)
+  const { pkgName, versionSelector } = parseScopedAliasBody(
+    body, res.name, res.raw, 'JSR'
+  )
+  const npmName = jsrToNpmPackageName(pkgName, res.raw)
+  const specString = versionSelector
+    ? `${npmName}@${versionSelector}`
+    : npmName
+  const subSpec = npa(specString, where)
+  validateAliasSubSpec(subSpec)
+  res.jsrName = pkgName
+  return subSpec
+}
+
+function fromGithubAlias (res, where) {
+  const body = res.rawSpec.substr('github:'.length)
+  const { pkgName, versionSelector } = parseScopedAliasBody(
+    body, res.name, res.raw, 'GitHub'
+  )
+  // GitHub Packages publishes under the original scoped name (unlike JSR).
+  const specString = versionSelector ? `${pkgName}@${versionSelector}` : pkgName
+  const subSpec = npa(specString, where)
+  validateAliasSubSpec(subSpec)
+  return subSpec
+}
+
+function fromAlias (res, where) {
+  const prefix = aliasPrefix(res.rawSpec)
+  let subSpec
+  if (prefix === 'jsr:') {
+    subSpec = fromJsrAlias(res, where)
+  } else if (prefix === 'github:') {
+    subSpec = fromGithubAlias(res, where)
+  } else {
+    subSpec = fromNpmAlias(res, where)
   }
 
   res.subSpec = subSpec
   res.registry = true
   res.type = 'alias'
+  res.aliasType = prefix.slice(0, -1) // 'npm' | 'jsr' | 'github'
   res.saveSpec = null
   res.fetchSpec = null
   return res

--- a/test/aliases.js
+++ b/test/aliases.js
@@ -1,0 +1,263 @@
+const t = require('tap')
+const npa = require('..')
+
+// Parsing shape for each alias form. Follows the table-style used by
+// test/github.js and test/basic.js.
+t.test('alias parsing', t => {
+  const tests = {
+    // --- npm: alias (existing behavior, regression-fenced) ---
+    'foo@npm:bar@1.0.0': {
+      name: 'foo',
+      type: 'alias',
+      aliasType: 'npm',
+      registry: true,
+      rawSpec: 'npm:bar@1.0.0',
+      saveSpec: null,
+      fetchSpec: null,
+      subSpec: {
+        registry: true,
+        name: 'bar',
+        type: 'version',
+        fetchSpec: '1.0.0',
+      },
+    },
+
+    // --- jsr: alias ---
+    // Scoped name + version — JSR remaps @<scope>/<name> to
+    // @jsr/<scope>__<name> so the @jsr:registry scope-config routes the
+    // fetch to the JSR npm-compat registry.
+    'foo@jsr:@scope/name@1.0.0': {
+      name: 'foo',
+      type: 'alias',
+      aliasType: 'jsr',
+      registry: true,
+      rawSpec: 'jsr:@scope/name@1.0.0',
+      saveSpec: null,
+      fetchSpec: null,
+      jsrName: '@scope/name',
+      subSpec: {
+        registry: true,
+        name: '@jsr/scope__name',
+        scope: '@jsr',
+        type: 'version',
+        fetchSpec: '1.0.0',
+      },
+    },
+
+    // Scoped name only — defaults to `*` range.
+    'foo@jsr:@scope/name': {
+      type: 'alias',
+      aliasType: 'jsr',
+      jsrName: '@scope/name',
+      subSpec: {
+        name: '@jsr/scope__name',
+        type: 'range',
+        fetchSpec: '*',
+      },
+    },
+
+    // Bare-version form — uses the alias name as the JSR package name.
+    '@scope/foo@jsr:^1.0.0': {
+      name: '@scope/foo',
+      type: 'alias',
+      aliasType: 'jsr',
+      jsrName: '@scope/foo',
+      subSpec: {
+        name: '@jsr/scope__foo',
+        type: 'range',
+        fetchSpec: '^1.0.0',
+      },
+    },
+
+    // Standalone spec without an alias name on the left.
+    'jsr:@scope/name@1.0.0': {
+      type: 'alias',
+      aliasType: 'jsr',
+      jsrName: '@scope/name',
+      subSpec: {
+        name: '@jsr/scope__name',
+        fetchSpec: '1.0.0',
+      },
+    },
+
+    // --- github: alias ---
+    // Scoped name + version — GitHub Packages keeps the original scoped
+    // name (unlike JSR, which remaps).
+    'foo@github:@owner/name@1.0.0': {
+      name: 'foo',
+      type: 'alias',
+      aliasType: 'github',
+      registry: true,
+      rawSpec: 'github:@owner/name@1.0.0',
+      saveSpec: null,
+      fetchSpec: null,
+      subSpec: {
+        registry: true,
+        name: '@owner/name',
+        scope: '@owner',
+        type: 'version',
+        fetchSpec: '1.0.0',
+      },
+    },
+
+    'foo@github:@owner/name': {
+      type: 'alias',
+      aliasType: 'github',
+      subSpec: {
+        name: '@owner/name',
+        type: 'range',
+        fetchSpec: '*',
+      },
+    },
+
+    '@scope/foo@github:^1.0.0': {
+      name: '@scope/foo',
+      type: 'alias',
+      aliasType: 'github',
+      subSpec: {
+        name: '@scope/foo',
+        type: 'range',
+        fetchSpec: '^1.0.0',
+      },
+    },
+
+    'github:@owner/name@1.0.0': {
+      type: 'alias',
+      aliasType: 'github',
+      subSpec: {
+        name: '@owner/name',
+        fetchSpec: '1.0.0',
+      },
+    },
+
+    // --- github: git-shortcut compatibility ---
+    // `github:<owner>/<repo>` is hosted-git-info's GitHub shortcut and must
+    // stay on the git path, not the alias path.
+    'foo@github:owner/repo': {
+      name: 'foo',
+      type: 'git',
+      aliasType: undefined,
+    },
+
+    'foo@github:owner/repo#main': {
+      name: 'foo',
+      type: 'git',
+      gitCommittish: 'main',
+      aliasType: undefined,
+    },
+
+    'foo@github:owner/repo#semver:^1.0.0': {
+      name: 'foo',
+      type: 'git',
+      gitRange: '^1.0.0',
+      aliasType: undefined,
+    },
+
+    // A scoped alias name does not rescue a body that is clearly a git
+    // shortcut (contains a slash).
+    '@scope/foo@github:owner/repo': {
+      name: '@scope/foo',
+      type: 'git',
+      aliasType: undefined,
+    },
+
+    // Bare-version body with an unscoped alias is ambiguous, so we do NOT
+    // claim it as a github alias. It falls through to other resolvers —
+    // here hosted-git-info happens to accept `^1.0.0` as a committish.
+    'foo@github:^1.0.0': {
+      type: 'git',
+      aliasType: undefined,
+    },
+  }
+
+  Object.keys(tests).forEach(arg => {
+    t.test(arg, t => {
+      const res = npa(arg)
+      t.ok(res instanceof npa.Result, `${arg} is a Result`)
+      t.match(res, tests[arg], `${arg} matches expectations`)
+      // All non-hosted results serialize through toJSON cleanly.
+      t.doesNotThrow(() => JSON.stringify(res), 'toJSON works')
+      t.end()
+    })
+  })
+
+  t.end()
+})
+
+t.test('alias errors', t => {
+  // --- JSR errors ---
+  t.throws(() => npa('foo@jsr:1.0.0'),
+    { code: 'EMISSINGJSRSCOPE' },
+    'unscoped alias + bare version: jsr pkg name must be scoped')
+  t.throws(() => npa('foo@jsr:foo@1.0.0'),
+    { code: 'EMISSINGJSRSCOPE' },
+    'unscoped pkg name in jsr body is rejected')
+  t.throws(() => npa('jsr:@foo'),
+    { code: 'EINVALIDJSRNAME' },
+    'scope without name is rejected')
+  t.throws(() => npa('jsr:@foo@^1.0.0'),
+    { code: 'EINVALIDJSRNAME' },
+    'scope-only pkg name with version is rejected')
+
+  // --- Alias invariants apply to all prefixes ---
+  // Aliases cannot nest regardless of which alias prefix is in play.
+  t.throws(() => npa('foo@npm:bar@npm:baz'),
+    { message: 'nested aliases not supported' },
+    'npm:npm nesting is rejected (existing behavior)')
+  t.throws(() => npa('foo@jsr:@scope/name@npm:bar@1'),
+    { message: 'nested aliases not supported' },
+    'jsr body that re-parses to an alias is rejected')
+  t.throws(() => npa('foo@github:@owner/name@npm:bar@1'),
+    { message: 'nested aliases not supported' },
+    'github body that re-parses to an alias is rejected')
+
+  // Aliases must resolve to registry deps — a file/git/url version selector
+  // is not permitted inside the body.
+  t.throws(() => npa('foo@npm:foo/bar'),
+    { message: 'aliases only work for registry deps' },
+    'npm alias body must be a registry spec (existing behavior)')
+  t.throws(() => npa('foo@jsr:@scope/name@file:./x'),
+    { message: 'aliases only work for registry deps' },
+    'jsr alias body must be a registry spec')
+  t.throws(() => npa('foo@github:@owner/name@git+ssh://x.com/y'),
+    { message: 'aliases only work for registry deps' },
+    'github alias body must be a registry spec')
+
+  // Aliases without any name on either side cannot resolve.
+  t.throws(() => npa('foo@npm:'),
+    { message: 'aliases must have a name' },
+    'empty npm alias body (existing behavior)')
+
+  t.end()
+})
+
+t.test('case-insensitive alias prefixes', t => {
+  t.equal(npa('foo@NPM:bar@1.0.0').aliasType, 'npm')
+  t.equal(npa('foo@JSR:@scope/name@1.0.0').aliasType, 'jsr')
+  t.equal(npa('foo@GITHUB:@owner/name@1.0.0').aliasType, 'github')
+  // Casing doesn't rescue `github:owner/repo` from the git-shortcut path —
+  // the compatibility rule applies regardless of prefix casing.
+  t.equal(npa('foo@GITHUB:owner/repo').type, 'git')
+  t.end()
+})
+
+t.test('aliasType is undefined on non-alias results', t => {
+  // New field on Result; must not leak onto specifiers that aren't aliases,
+  // since downstream code (e.g. arborist save logic) branches on it.
+  t.equal(npa('foo@1.0.0').aliasType, undefined, 'version')
+  t.equal(npa('foo@^1.0.0').aliasType, undefined, 'range')
+  t.equal(npa('foo@latest').aliasType, undefined, 'tag')
+  t.equal(npa('github:owner/repo').aliasType, undefined, 'git shortcut')
+  t.equal(npa('https://x.com/f.tgz').aliasType, undefined, 'remote')
+  t.end()
+})
+
+t.test('toString on alias results round-trips the rawSpec', t => {
+  // saveSpec and fetchSpec are null on aliases, so toString falls back to
+  // rawSpec. This matters because arborist/pacote display the spec to
+  // users via toString in a few places.
+  t.equal(npa('foo@npm:bar@1.0.0').toString(), 'foo@npm:bar@1.0.0')
+  t.equal(npa('foo@jsr:@scope/name@1.0.0').toString(), 'foo@jsr:@scope/name@1.0.0')
+  t.equal(npa('foo@github:@owner/name@1.0.0').toString(), 'foo@github:@owner/name@1.0.0')
+  t.end()
+})


### PR DESCRIPTION
Adds support for `jsr:` and `github:` alias prefixes to npm-package-arg, alongside the existing `npm:` alias. Aliases now  resolve to registry dependencies that are routed by standard scoped-registry config, so no new fetch machinery is required downstream.

## Motivation

JSR and GitHub Packages both publish via npm-compatible registries, but today there's no first-class way in a package.json spec to declare "this dependency comes from JSR/GitHub Packages" - JSR in particular requires knowing its internal @jsr/<scope>__<name> mangling. A jsr: / github: prefix on a dependency spec encodes the source registry (and, for JSR, the scoped-name remapping) in one place, with optional local renaming as a bonus - matching pnpm's shape

This is very useful in case an organization uses a mix of private and public packages within the same namespace, e. g. all public packages are on npm, while all private ones (protected by auth) are on GitHub Packages. Currently managing such mix within a single project is very painful.

## What's new

- jsr: aliases - foo@jsr:@scope/name@1.0.0 remaps the scoped name to @jsr/<scope>__<name> (matching JSR's npm-compat layout, same algorithm pnpm uses) so the @jsr scope config routes the fetch. The original scoped name is preserved on the result as jsrName.
- github: aliases - foo@github:@owner/name@1.0.0 keeps the original scoped name (GitHub Packages doesn't remap) and relies on @<owner>:registry=… scope config.
- Bare-version form - when the alias name is itself scoped, @scope/foo@jsr:^1.0.0 and @scope/foo@github:^1.0.0 are accepted, using the alias name as the package name.
- New Result fields:
  - aliasType: 'npm' | 'jsr' | 'github' on alias results, undefined otherwise.
  - jsrName: the user-written scoped JSR name; subSpec.name holds the remapped @jsr/… form used for fetching.

## Backwards-compatibility: github: vs hosted-git-info

github:<owner>/<repo> has long been hosted-git-info's shorthand for a GitHub git repository, and that must keep working. The github: alias path is therefore only taken when the body is unambiguously not a git shortcut:

- github:@<owner>/<name>[@<version>] - scoped package name → alias
- <@scope/name>@github:<version> - bare version with a scoped alias → alias
- everything else (github:owner/repo, github:owner/repo#main, github:owner/repo#semver:…, github:abcd1234, bare version without a scoped alias) → still a git spec, deferred to hosted-git-info

Existing type: 'alias' / npm: behavior is unchanged and regression-fenced by tests.


Note that this will also require a small change on https://github.com/npm/cli to work, PR pending