### PR TITLE
fix: skip hosted git parsing for registry specs

### DIFF
--- a/lib/npa.js
+++ b/lib/npa.js
@@ -14,6 +14,7 @@ const { log } = require('proc-log')
 const hasSlashes = isWindows ? /\\|[/]/ : /[/]/
 const isURL = /^(?:git[+])?[a-z]+:/i
 const isGit = /^[^@]+@[^:.]+\.[^:]+:.+$/i
+const isHostedGitShortcut = /^[^/@\s][^/\s]*\/[^/\s]+(?:#.*)?$/i
 const isFileType = /[.](?:tgz|tar\.gz|tar)$/i
 const isPortNumber = /:[0-9]+(\/|$)/i
 const isWindowsFile = /^(?:[.]|~[/]|[/\\]|[a-zA-Z]:)/
@@ -76,6 +77,10 @@ function isAliasSpec (spec) {
   return spec.toLowerCase().startsWith('npm:')
 }
 
+function isHostedGitSpec (spec) {
+  return spec && (isURL.test(spec) || isGit.test(spec) || isHostedGitShortcut.test(spec))
+}
+
 function resolve (name, spec, where, arg) {
   const res = new Result({
     raw: arg,
@@ -98,10 +103,12 @@ function resolve (name, spec, where, arg) {
     return fromAlias(res, where)
   }
 
-  const hosted = HostedGit.fromUrl(spec, {
-    noGitPlus: true,
-    noCommittish: true,
-  })
+  const hosted = isHostedGitSpec(spec)
+    ? HostedGit.fromUrl(spec, {
+      noGitPlus: true,
+      noCommittish: true,
+    })
+    : null
   if (hosted) {
     return fromHostedGit(res, hosted)
   } else if (spec && isURL.test(spec)) {

--- a/test/basic.js
+++ b/test/basic.js
@@ -13,6 +13,25 @@ const normalizePaths = spec => {
 const t = require('tap')
 const npa = t.mock('..', { path })
 
+t.test('skips hosted git parsing for registry specs', t => {
+  const calls = []
+  const mockedNpa = t.mock('..', {
+    path,
+    'hosted-git-info': {
+      fromUrl: spec => {
+        calls.push(spec)
+        return null
+      },
+    },
+  })
+
+  mockedNpa('foo')
+  mockedNpa('foo@^1.2.3')
+  mockedNpa('foo@latest')
+  t.strictSame(calls, [])
+  t.end()
+})
+
 t.test('basic', function (t) {
   const tests = {
     'foo@1.2': {


### PR DESCRIPTION
Fixes #219.

Registry package specs like `foo`, `foo@^1.2.3`, and `foo@latest` cannot resolve to hosted git dependencies, but `resolve()` currently calls `HostedGit.fromUrl()` before falling back to registry parsing. In large installs this means ordinary registry dependency specs still pay the URL parsing cost from `hosted-git-info`.

This adds a lightweight pre-check so `HostedGit.fromUrl()` is only called for specs that look like URLs, scp-style git specs, or supported hosted git shortcuts such as `user/repo`.

Verification:

- `npx tap --no-coverage test/basic.js`
- `npm run eslint -- lib/npa.js test/basic.js`
- `git diff --check`
- `npm test` passes tests, coverage, and eslint locally, then fails only in `template-oss-check` because the generated repository template wants unrelated `.github` branch/template updates. I did not include those unrelated tooling changes in this bugfix PR.
